### PR TITLE
Set default location to 0 0 0

### DIFF
--- a/unity/Assets/Scenes/SampleScene.unity
+++ b/unity/Assets/Scenes/SampleScene.unity
@@ -2241,7 +2241,7 @@ Transform:
   m_GameObject: {fileID: 336173537}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.025564875, y: 0.75816494, z: -7.080446}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []


### PR DESCRIPTION
The quest should always be reporting 0 0 0, its _much_ easier for the robot code to translate that more if necessary