### PR TITLE
More Robust Pose Resetting

### DIFF
--- a/unity/Assets/Robot/MotionStreamer.cs
+++ b/unity/Assets/Robot/MotionStreamer.cs
@@ -7,54 +7,175 @@ using TMPro;
 using UnityEngine.UI;
 using System;
 
+/// <summary>
+/// Extension methods for Unity's Vector3 class to convert to array format.
+/// </summary>
 public static class VectorExtensions
 {
+    /// <summary>
+    /// Converts a Vector3 to a float array containing x, y, and z components.
+    /// </summary>
+    /// <param name="vector">The Vector3 to convert</param>
+    /// <returns>Float array containing [x, y, z] values</returns>
     public static float[] ToArray(this Vector3 vector)
     {
         return new float[] { vector.x, vector.y, vector.z };
     }
 }
 
+/// <summary>
+/// Extension methods for Unity's Quaternion class to convert to array format.
+/// </summary>
 public static class QuaternionExtensions
 {
+    /// <summary>
+    /// Converts a Quaternion to a float array containing x, y, z, and w components.
+    /// </summary>
+    /// <param name="quaternion">The Quaternion to convert</param>
+    /// <returns>Float array containing [x, y, z, w] values</returns>
     public static float[] ToArray(this Quaternion quaternion)
     {
         return new float[] { quaternion.x, quaternion.y, quaternion.z, quaternion.w };
     }
 }
 
+/// <summary>
+/// Manages streaming of VR motion data to a FRC robot through NetworkTables.
+/// Handles pose tracking, reset operations, and network communication.
+/// </summary>
 public class MotionStreamer : MonoBehaviour
 {
-    /* Initialize local variables */
+    #region Fields
+    /// <summary>
+    /// Current frame index from Unity's Time.frameCount
+    /// </summary>
     public int frameIndex;
+
+    /// <summary>
+    /// Current timestamp from Unity's Time.time
+    /// </summary>
     public double timeStamp;
+
+    /// <summary>
+    /// Current position of the VR headset
+    /// </summary>
     public Vector3 position;
+
+    /// <summary>
+    /// Current rotation of the VR headset as a Quaternion
+    /// </summary>
     public Quaternion rotation;
+
+    /// <summary>
+    /// Current rotation of the VR headset in Euler angles
+    /// </summary>
     public Vector3 eulerAngles;
+
+    /// <summary>
+    /// Reference to the OVR Camera Rig for tracking
+    /// </summary>
     public OVRCameraRig cameraRig;
+
+    /// <summary>
+    /// NetworkTables connection for FRC data communication
+    /// </summary>
     public Nt4Source frcDataSink = null;
+
+    /// <summary>
+    /// Current command received from the robot
+    /// </summary>
     private long command = 0;
+
+    /// <summary>
+    /// Flag indicating if a reset operation is in progress
+    /// </summary>
     private bool resetInProgress = false;
 
+    /// <summary>
+    /// Input field for team number entry
+    /// </summary>
     public TMP_InputField teamInput;
+
+    /// <summary>
+    /// Button to update team number
+    /// </summary>
     public Button teamUpdateButton;
+
+    /// <summary>
+    /// Default team number text
+    /// </summary>
     public static string inputText = "5152";
+
+    /// <summary>
+    /// Current team number
+    /// </summary>
     private string teamNumber = "";
 
-    [SerializeField] public Transform vrCamera;
-    [SerializeField] public Transform vrCameraRoot;
-    [SerializeField] public Transform resetTransform; // The desired position & rotation (look direction) for your player
+    /// <summary>
+    /// Reference to the VR camera transform
+    /// </summary>
+    [SerializeField] 
+    public Transform vrCamera;
+
+    /// <summary>
+    /// Reference to the VR camera root transform
+    /// </summary>
+    [SerializeField] 
+    public Transform vrCameraRoot;
+
+    /// <summary>
+    /// Reference to the reset position transform
+    /// </summary>
+    [SerializeField] 
+    public Transform resetTransform;
+
+    /// <summary>
+    /// Current battery percentage of the device
+    /// </summary>
     private float batteryPercent = 0;
 
-    /* NT configuration settings */
+    #region NetworkTables Configuration
+    /// <summary>
+    /// Application name for NetworkTables connection
+    /// </summary>
     private readonly string appName = "Quest3S";
-    private readonly string serverAddress = "10.TE.AM.2";
-    private readonly string serverDNS = "roboRIO-####-FRC.local";
-    private string ipAddress = "";
-    private bool useAddress = true;
-    private readonly int serverPort = 5810;
-    private int delayCounter = 0;
 
+    /// <summary>
+    /// Server address format for NetworkTables connection
+    /// </summary>
+    private readonly string serverAddress = "10.TE.AM.2";
+
+    /// <summary>
+    /// DNS format for roboRIO connection
+    /// </summary>
+    private readonly string serverDNS = "roboRIO-####-FRC.local";
+
+    /// <summary>
+    /// Current IP address for connection
+    /// </summary>
+    private string ipAddress = "";
+
+    /// <summary>
+    /// Flag to toggle between IP and DNS connection methods
+    /// </summary>
+    private bool useAddress = true;
+
+    /// <summary>
+    /// NetworkTables server port
+    /// </summary>
+    private readonly int serverPort = 5810;
+
+    /// <summary>
+    /// Counter for connection retry delay
+    /// </summary>
+    private int delayCounter = 0;
+    #endregion
+    #endregion
+
+    #region Unity Lifecycle Methods
+    /// <summary>
+    /// Initializes the connection and UI components
+    /// </summary>
     void Start()
     {
         OVRPlugin.systemDisplayFrequency = 120.0f;
@@ -66,6 +187,9 @@ public class MotionStreamer : MonoBehaviour
         teamInput.onSelect.AddListener(OnInputFieldSelected);
     }
 
+    /// <summary>
+    /// Handles frame updates for data publishing and command processing
+    /// </summary>
     void LateUpdate()
     {
         if (frcDataSink.Client.Connected())
@@ -87,7 +211,12 @@ public class MotionStreamer : MonoBehaviour
             HandleDisconnectedState();
         }
     }
+    #endregion
 
+    #region Network Connection Methods
+    /// <summary>
+    /// Establishes connection to the robot using either IP or DNS
+    /// </summary>
     private void ConnectToRobot()
     {
         if (useAddress == true)
@@ -117,6 +246,9 @@ public class MotionStreamer : MonoBehaviour
         PublishTopics();
     }
 
+    /// <summary>
+    /// Handles reconnection when connection is lost
+    /// </summary>
     private void HandleDisconnectedState()
     {
         Debug.Log("[MotionStreamer] Robot disconnected. Resetting connection and attempting to reconnect...");
@@ -124,6 +256,9 @@ public class MotionStreamer : MonoBehaviour
         ConnectToRobot();
     }
 
+    /// <summary>
+    /// Publishes and subscribes to required NetworkTables topics
+    /// </summary>
     private void PublishTopics()
     {
         frcDataSink.PublishTopic("/questnav/miso", "int");
@@ -136,9 +271,14 @@ public class MotionStreamer : MonoBehaviour
         frcDataSink.Subscribe("/questnav/mosi", 0.1, false, false, false);
         frcDataSink.Subscribe("/questnav/init/position", 0.1, false, false, false);
         frcDataSink.Subscribe("/questnav/init/eulerAngles", 0.1, false, false, false);
-        frcDataSink.Subscribe("/questnav/resetpose", 0.1, false, false, false);  // Single subscription for reset pose array
+        frcDataSink.Subscribe("/questnav/resetpose", 0.1, false, false, false);
     }
+    #endregion
 
+    #region Data Publishing Methods
+    /// <summary>
+    /// Publishes current frame data to NetworkTables
+    /// </summary>
     private void PublishFrameData()
     {
         frameIndex = Time.frameCount;
@@ -155,7 +295,12 @@ public class MotionStreamer : MonoBehaviour
         frcDataSink.PublishValue("/questnav/eulerAngles", eulerAngles.ToArray());
         frcDataSink.PublishValue("/questnav/batteryPercent", batteryPercent);
     }
+    #endregion
 
+    #region Command Processing Methods
+    /// <summary>
+    /// Processes commands received from the robot
+    /// </summary>
     private void ProcessCommands()
     {
         command = frcDataSink.GetLong("/questnav/mosi");
@@ -199,23 +344,27 @@ public class MotionStreamer : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Initiates a pose reset based on received NetworkTables data
+    /// </summary>
     private void InitiatePoseReset()
     {
         try {
-            const int maxRetries = 3;
-            const float retryDelayMs = 50f;
-
-            // FRC field boundaries in meters
-            const float FIELD_LENGTH = 16.54f;
-            const float FIELD_WIDTH = 8.02f;
+            // Constants for retry logic and field dimensions
+            const int maxRetries = 3;              // Maximum number of attempts to read pose data
+            const float retryDelayMs = 50f;        // Delay between retry attempts
+            const float FIELD_LENGTH = 16.54f;     // FRC field length in meters
+            const float FIELD_WIDTH = 8.02f;       // FRC field width in meters
 
             double[] resetPose = null;
             bool success = false;
             int attemptCount = 0;
 
+            // Attempt to read pose data from NetworkTables with retry logic
             for (int i = 0; i < maxRetries && !success; i++)
             {
                 attemptCount++;
+                // Add delay between retries to allow for network latency
                 if (i > 0) {
                     System.Threading.Thread.Sleep((int)retryDelayMs);
                     Debug.Log($"[MotionStreamer] Attempt {attemptCount} of {maxRetries}...");
@@ -223,11 +372,13 @@ public class MotionStreamer : MonoBehaviour
 
                 Debug.Log($"[MotionStreamer] Reading NetworkTables Values (Attempt {attemptCount}):");
 
+                // Read the pose array from NetworkTables
+                // Format: [X, Y, Rotation] in FRC field coordinates
                 resetPose = frcDataSink.GetDoubleArray("/questnav/resetpose");
 
-                // Check if we got valid data
+                // Validate pose data format and field boundaries
                 if (resetPose != null && resetPose.Length == 3) {
-                    // Validate field boundaries - from (0,0) to (LENGTH, WIDTH)
+                    // Check if pose is within valid field boundaries
                     if (resetPose[0] < 0 || resetPose[0] > FIELD_LENGTH ||
                         resetPose[1] < 0 || resetPose[1] > FIELD_WIDTH) {
                         Debug.LogWarning($"[MotionStreamer] Reset pose outside field boundaries: X:{resetPose[0]:F3} Y:{resetPose[1]:F3}");
@@ -240,49 +391,53 @@ public class MotionStreamer : MonoBehaviour
                 Debug.Log($"[MotionStreamer] Values (Attempt {attemptCount}): X:{resetPose?[0]:F3} Y:{resetPose?[1]:F3} Rot:{resetPose?[2]:F3}");
             }
 
+            // Exit if we couldn't get valid pose data
             if (!success) {
                 Debug.LogWarning($"[MotionStreamer] Failed to read valid reset pose values after {attemptCount} attempts");
                 return;
             }
 
-            double resetX = resetPose[0];
-            double resetY = resetPose[1];
-            double resetRotation = resetPose[2];
+            // Extract pose components from the array
+            double resetX = resetPose[0];          // FRC X coordinate (along length of field)
+            double resetY = resetPose[1];          // FRC Y coordinate (along width of field)
+            double resetRotation = resetPose[2];   // FRC rotation (CCW positive)
 
-            // Normalize rotation to -180 to 180 degrees
+            // Normalize rotation to -180 to 180 degrees range
             while (resetRotation > 180) resetRotation -= 360;
             while (resetRotation < -180) resetRotation += 360;
 
-            // Also log MOSI value
-            long mosi = frcDataSink.GetLong("/questnav/mosi");
-            Debug.Log($"[MotionStreamer] mosi: {mosi}");
-
             Debug.Log($"[MotionStreamer] Starting pose reset - Target: FRC X:{resetX:F2} Y:{resetY:F2} Rot:{resetRotation:F2}°");
 
-            // Store current states for reference
+            // Store current VR camera state for reference
             Vector3 currentCameraPos = vrCamera.position;
             Quaternion currentCameraRot = vrCamera.rotation;
 
             Debug.Log($"[MotionStreamer] Before reset - Camera Pos:{currentCameraPos:F3} Rot:{currentCameraRot.eulerAngles:F3}");
 
-            // 2. Convert FRC coordinates to Unity coordinates
+            // Convert FRC coordinates to Unity coordinates:
+            // - Unity X = -FRC Y (right is positive in Unity)
+            // - Unity Y = kept unchanged (height)
+            // - Unity Z = FRC X (forward is positive in both)
             Vector3 targetUnityPosition = new Vector3(
-                (float)(-resetY),        // Unity X = -FRC Y (right is positive in Unity)
-                currentCameraPos.y,      // Maintain current height
-                (float)resetX           // Unity Z = FRC X (forward is positive in both)
+                (float)(-resetY),         // Negate Y for Unity's coordinate system
+                currentCameraPos.y,       // Maintain current height
+                (float)resetX            // FRC X maps directly to Unity Z
             );
 
-            // 3. Calculate deltas in world space
+            // Calculate the position difference we need to move
             Vector3 positionDelta = targetUnityPosition - currentCameraPos;
 
-            // 4. Handle rotation
-            float targetUnityYaw = (float)(-resetRotation);  // Negate because Unity is clockwise
+            // Convert FRC rotation to Unity rotation:
+            // - Unity uses clockwise positive rotation around Y
+            // - FRC uses counterclockwise positive rotation
+            float targetUnityYaw = (float)(-resetRotation);  // Negate for Unity's rotation direction
             float currentYaw = currentCameraRot.eulerAngles.y;
 
-            // Normalize yaw angles
+            // Normalize both angles to 0-360 range for proper delta calculation
             while (currentYaw < 0) currentYaw += 360;
             while (targetUnityYaw < 0) targetUnityYaw += 360;
 
+            // Calculate rotation delta and normalize to -180 to 180 range
             float yawDelta = targetUnityYaw - currentYaw;
             if (yawDelta > 180) yawDelta -= 360;
             if (yawDelta < -180) yawDelta += 360;
@@ -290,28 +445,29 @@ public class MotionStreamer : MonoBehaviour
             Debug.Log($"[MotionStreamer] Calculated adjustments - Position delta:{positionDelta:F3} Rotation delta:{yawDelta:F3}°");
             Debug.Log($"[MotionStreamer] Target Unity Position: {targetUnityPosition:F3}");
 
-            // 5. Apply transformations
-            // Store original root-to-camera offset
+            // Store the original offset between camera and its root
+            // This helps maintain proper VR tracking space
             Vector3 cameraOffset = vrCamera.position - vrCameraRoot.position;
 
-            // First rotate the root
+            // First rotate the root around the camera position
+            // This maintains the camera's position while changing orientation
             vrCameraRoot.RotateAround(vrCamera.position, Vector3.up, yawDelta);
 
-            // Then move the root by the required delta
+            // Then apply the position adjustment to achieve target position
             vrCameraRoot.position += positionDelta;
 
-            // 6. Verify result
+            // Log final position and rotation for verification
             Debug.Log($"[MotionStreamer] After reset - Camera Pos:{vrCamera.position:F3} Rot:{vrCamera.rotation.eulerAngles:F3}");
 
-            // 7. Verify the position error
+            // Calculate and check position error to ensure accuracy
             float posError = Vector3.Distance(vrCamera.position, targetUnityPosition);
             Debug.Log($"[MotionStreamer] Position error after reset: {posError:F3}m");
 
-            if (posError > 0.01f) {
+            // Warn if position error is larger than expected threshold
+            if (posError > 0.01f) {  // 1cm threshold
                 Debug.LogWarning($"[MotionStreamer] Large position error detected!");
             }
 
-            // 8. Send success acknowledgment
             frcDataSink.PublishValue("/questnav/miso", 98);
         }
         catch (Exception e) {
@@ -322,7 +478,10 @@ public class MotionStreamer : MonoBehaviour
         }
     }
 
-    // Transform the HMD's rotation to virtually "zero" the robot position. Similar result as long-pressing the Oculus button.
+    /// <summary>
+    /// Recenters the player's view by adjusting the VR camera root transform to match the reset transform.
+    /// Similar to the effect of long-pressing the Oculus button.
+    /// </summary>
     void RecenterPlayer()
     {
         try {
@@ -333,17 +492,21 @@ public class MotionStreamer : MonoBehaviour
             Vector3 distanceDiff = resetTransform.position - vrCamera.position;
             vrCameraRoot.transform.position += distanceDiff;
 
-            // Send OK value
             frcDataSink.PublishValue("/questnav/miso", 99);
         }
         catch (Exception e) {
-        Debug.LogError($"[MotionStreamer] Error during pose reset: {e.Message}");
-        Debug.LogException(e);
-        frcDataSink.PublishValue("/questnav/miso", 0);
-        resetInProgress = false;
+            Debug.LogError($"[MotionStreamer] Error during pose reset: {e.Message}");
+            Debug.LogException(e);
+            frcDataSink.PublishValue("/questnav/miso", 0);
+            resetInProgress = false;
+        }
     }
-    }
+    #endregion
 
+    #region UI Methods
+    /// <summary>
+    /// Updates the team number based on user input and triggers a connection reset
+    /// </summary>
     public void UpdateTeamNumber()
     {
         Debug.Log("[MotionStreamer] Updating Team Number");
@@ -354,6 +517,10 @@ public class MotionStreamer : MonoBehaviour
         HandleDisconnectedState();
     }
 
+    /// <summary>
+    /// Sets the input box placeholder text with the current team number
+    /// </summary>
+    /// <param name="team">The team number to display</param>
     private void setInputBox(string team)
     {
         teamInput.text = "";
@@ -367,12 +534,22 @@ public class MotionStreamer : MonoBehaviour
             Debug.LogError("Placeholder is not assigned or not a TextMeshProUGUI component.");
         }
     }
+    #endregion
 
+    #region Helper Methods
+    /// <summary>
+    /// Generates the DNS address for the roboRIO based on team number
+    /// </summary>
+    /// <returns>The formatted DNS address string</returns>
     private string getDNS()
     {
         return serverDNS.Replace("####", teamNumber);
     }
 
+    /// <summary>
+    /// Generates the IP address for the roboRIO based on team number
+    /// </summary>
+    /// <returns>The formatted IP address string</returns>
     private string getIP()
     {
         string tePart = teamNumber.Length > 2 ? teamNumber.Substring(0, teamNumber.Length - 2) : "0";
@@ -380,8 +557,13 @@ public class MotionStreamer : MonoBehaviour
         return serverAddress.Replace("TE", tePart).Replace("AM", amPart);
     }
 
+    /// <summary>
+    /// Event handler for when the input field is selected
+    /// </summary>
+    /// <param name="text">The current text in the input field</param>
     private void OnInputFieldSelected(string text)
     {
         Debug.Log("[MotionStreamer] Input Selected");
     }
+    #endregion
 }

--- a/unity/Assets/Robot/MotionStreamer.cs
+++ b/unity/Assets/Robot/MotionStreamer.cs
@@ -44,7 +44,7 @@ public class MotionStreamer : MonoBehaviour
 
     public TMP_InputField teamInput;
     public Button teamUpdateButton;
-    public static string inputText = "9999";
+    public static string inputText = "5152"; // Default to my team
     private string teamNumber = "";
 
     [SerializeField] public Transform poseOffset;
@@ -65,7 +65,7 @@ public class MotionStreamer : MonoBehaviour
     void Start()
     {
         OVRPlugin.systemDisplayFrequency = 120.0f;
-        teamNumber = PlayerPrefs.GetString("TeamNumber", "9999");
+        teamNumber = PlayerPrefs.GetString("TeamNumber", "5152"); // Default to my team
         setInputBox(teamNumber);
         teamInput.Select();
         ConnectToRobot();

--- a/unity/Assets/Robot/MotionStreamer.cs
+++ b/unity/Assets/Robot/MotionStreamer.cs
@@ -104,7 +104,7 @@ public class MotionStreamer : MonoBehaviour
     /// <summary>
     /// Default team number text
     /// </summary>
-    public static string inputText = "5152";
+    public static string inputText = "9999";
 
     /// <summary>
     /// Current team number
@@ -179,7 +179,7 @@ public class MotionStreamer : MonoBehaviour
     void Start()
     {
         OVRPlugin.systemDisplayFrequency = 120.0f;
-        teamNumber = PlayerPrefs.GetString("TeamNumber", "5152");
+        teamNumber = PlayerPrefs.GetString("TeamNumber", "9999");
         setInputBox(teamNumber);
         teamInput.Select();
         ConnectToRobot();

--- a/unity/Assets/Robot/MotionStreamer.cs
+++ b/unity/Assets/Robot/MotionStreamer.cs
@@ -1,6 +1,3 @@
-/* Unity-based example for publishing Quest headset data to FRC-compatible Network Tables */
-/* Juan Chong, Jason Daming - 2024 */
-/* Refer to the README.md for setup instructions and LICENSE for licensing information */
 using UnityEngine;
 using NetworkTables;
 using System.Net;
@@ -10,7 +7,6 @@ using TMPro;
 using UnityEngine.UI;
 using System;
 
-/* Extend Vector3 with a ToArray() function */
 public static class VectorExtensions
 {
     public static float[] ToArray(this Vector3 vector)
@@ -19,7 +15,6 @@ public static class VectorExtensions
     }
 }
 
-/* Extend Quaternion with a ToArray() function */
 public static class QuaternionExtensions
 {
     public static float[] ToArray(this Quaternion quaternion)
@@ -31,47 +26,43 @@ public static class QuaternionExtensions
 public class MotionStreamer : MonoBehaviour
 {
     /* Initialize local variables */
-    public int frameIndex; // Local variable to store the headset frame index
-    public double timeStamp; // Local variable to store the headset timestamp
-    public double [] letpositionArray; // Local variable to store the initial headset position
-    public double[] eulerAnglesArray; 
-    public Vector3 position; // Local variable to store the headset position in 3D space
-    public Quaternion rotation; // Local variable to store the headset rotation in quaternion form
-    public Vector3 eulerAngles; // Local variable to store the headset rotation in Euler angles
+    public int frameIndex;
+    public double timeStamp;
+    public Vector3 position;
+    public Quaternion rotation;
+    public Vector3 eulerAngles;
     public OVRCameraRig cameraRig;
     public Nt4Source frcDataSink = null;
     private long command = 0;
+    private bool resetInProgress = false;
 
     public TMP_InputField teamInput;
     public Button teamUpdateButton;
-    public static string inputText = "5152"; // Default to my team
+    public static string inputText = "5152";
     private string teamNumber = "";
 
-    [SerializeField] public Transform poseOffset;
-    [SerializeField] public Transform vrCamera; // The VR camera transform
-    [SerializeField] public Transform vrCameraRoot; // The root of the camera transform
+    [SerializeField] public Transform vrCamera;
+    [SerializeField] public Transform vrCameraRoot;
     [SerializeField] public Transform resetTransform; // The desired position & rotation (look direction) for your player
-    private float batteryPercent = 0; // Local variable to store the headset battery level
+    private float batteryPercent = 0;
 
     /* NT configuration settings */
-    private readonly string appName = "Quest3S"; // A fun name to ID the client in the robot logs
-    private readonly string serverAddress = "10.TE.AM.2"; // RoboRIO IP Address (typically 10.TE.AM.2)
-    private readonly string serverDNS = "roboRIO-####-FRC.local"; // RoboRIO DNS Address
+    private readonly string appName = "Quest3S";
+    private readonly string serverAddress = "10.TE.AM.2";
+    private readonly string serverDNS = "roboRIO-####-FRC.local";
     private string ipAddress = "";
     private bool useAddress = true;
-    private readonly int serverPort = 5810; // Typically 5810
-    private int delayCounter = 0; // Counter used to delay checking for commands from the robot
+    private readonly int serverPort = 5810;
+    private int delayCounter = 0;
 
     void Start()
     {
         OVRPlugin.systemDisplayFrequency = 120.0f;
-        teamNumber = PlayerPrefs.GetString("TeamNumber", "5152"); // Default to my team
+        teamNumber = PlayerPrefs.GetString("TeamNumber", "5152");
         setInputBox(teamNumber);
         teamInput.Select();
         ConnectToRobot();
-        // Register the click listener on the button
         teamUpdateButton.onClick.AddListener(UpdateTeamNumber);
-        // Subscribe to the TMP InputField's OnSelect event
         teamInput.onSelect.AddListener(OnInputFieldSelected);
     }
 
@@ -97,7 +88,6 @@ public class MotionStreamer : MonoBehaviour
         }
     }
 
-    // Connect to the RoboRIO and publish topics
     private void ConnectToRobot()
     {
         if (useAddress == true)
@@ -110,7 +100,6 @@ public class MotionStreamer : MonoBehaviour
             try
             {
                 IPHostEntry hostEntry = Dns.GetHostEntry(getDNS());
-                //Filter to just IPv4 addresses
                 IPAddress[] ipv4Addresses = hostEntry.AddressList
                    .Where(ip => ip.AddressFamily == AddressFamily.InterNetwork)
                    .ToArray();
@@ -118,25 +107,23 @@ public class MotionStreamer : MonoBehaviour
             }
             catch (Exception ex)
             {
-                UnityEngine.Debug.Log($"Error resolving DNS name: {ex.Message}");
+                Debug.Log($"Error resolving DNS name: {ex.Message}");
             }
 
             useAddress = true;
         }
-        UnityEngine.Debug.Log("[MotionStreamer] Attempting to connect to the RoboRIO at " + ipAddress + ".");
+        Debug.Log("[MotionStreamer] Attempting to connect to the RoboRIO at " + ipAddress + ".");
         frcDataSink = new Nt4Source(appName, ipAddress, serverPort);
         PublishTopics();
     }
 
-    // Handle the disconnected state (RIO reboot, code restart, etc.)
     private void HandleDisconnectedState()
-    {   
-        UnityEngine.Debug.Log("[MotionStreamer] Robot disconnected. Resetting connection and attempting to reconnect...");
+    {
+        Debug.Log("[MotionStreamer] Robot disconnected. Resetting connection and attempting to reconnect...");
         frcDataSink.Client.Disconnect();
         ConnectToRobot();
     }
 
-    // Publish topics to Network Tables
     private void PublishTopics()
     {
         frcDataSink.PublishTopic("/questnav/miso", "int");
@@ -149,13 +136,13 @@ public class MotionStreamer : MonoBehaviour
         frcDataSink.Subscribe("/questnav/mosi", 0.1, false, false, false);
         frcDataSink.Subscribe("/questnav/init/position", 0.1, false, false, false);
         frcDataSink.Subscribe("/questnav/init/eulerAngles", 0.1, false, false, false);
+        frcDataSink.Subscribe("/questnav/resetpose", 0.1, false, false, false);  // Single subscription for reset pose array
     }
 
-    // Publish the Quest pose data to Network Tables
     private void PublishFrameData()
     {
-        frameIndex = UnityEngine.Time.frameCount;
-        timeStamp = UnityEngine.Time.time;
+        frameIndex = Time.frameCount;
+        timeStamp = Time.time;
         position = cameraRig.centerEyeAnchor.position;
         rotation = cameraRig.centerEyeAnchor.rotation;
         eulerAngles = cameraRig.centerEyeAnchor.eulerAngles;
@@ -169,107 +156,214 @@ public class MotionStreamer : MonoBehaviour
         frcDataSink.PublishValue("/questnav/batteryPercent", batteryPercent);
     }
 
-    // Process commands from the robot
     private void ProcessCommands()
     {
         command = frcDataSink.GetLong("/questnav/mosi");
-        switch (command)
+
+        if (resetInProgress && command == 0)
         {
-            case 1:
-                RecenterPlayer();
-                UnityEngine.Debug.Log("[MotionStreamer] Processed a heading reset request.");
-                frcDataSink.PublishValue("/questnav/miso", 99);
-                break;
-            case 2:
-                InitPose();
-                UnityEngine.Debug.Log("[MotionStreamer] Processed a pose reset request.");
-                frcDataSink.PublishValue("/questnav/miso", 99);
-                break;
-            default:
-                frcDataSink.PublishValue("/questnav/miso", 0);
-                break;
-        }
-    }
-
-    // Clean up if the app crashes or is stopped
-    void OnApplicationQuit()
-    {
-
-    }
-
-    // Transform the HMD's pose to match a specific position and rotation in the Quest's coordinate system
-    void RecenterPlayer()
-    {
-        // Get the desired position and rotation from the robot
-        letpositionArray = frcDataSink.GetDoubleArray("/questnav/init/position");
-        eulerAnglesArray = frcDataSink.GetDoubleArray("/questnav/init/eulerAngles");
-        
-        if (letpositionArray.Length < 3 || eulerAnglesArray.Length < 4)
-        {
-            Debug.LogWarning("[MotionStreamer] Received invalid position/rotation data for recentering");
+            resetInProgress = false;
+            Debug.Log("[MotionStreamer] Reset operation completed");
             return;
         }
 
-        // Create the target pose
-        Vector3 targetPosition = new Vector3((float)letpositionArray[0], 
-                                           (float)letpositionArray[1], 
-                                           (float)letpositionArray[2]);
-        
-        Quaternion targetRotation = new Quaternion((float)eulerAnglesArray[0],
-                                                  (float)eulerAnglesArray[1],
-                                                  (float)eulerAnglesArray[2],
-                                                  (float)eulerAnglesArray[3]);
-
-        // Calculate the difference between current and target poses
-        Vector3 positionDiff = targetPosition - vrCamera.position;
-        float rotationAngleY = vrCamera.rotation.eulerAngles.y - targetRotation.eulerAngles.y;
-
-        // Apply the transformation to the camera root
-        vrCameraRoot.transform.Rotate(0, -rotationAngleY, 0);
-        vrCameraRoot.transform.position += positionDiff;
+        switch (command)
+        {
+            case 1:
+                if (!resetInProgress)
+                {
+                    Debug.Log("[MotionStreamer] Received heading reset request, initiating recenter...");
+                    RecenterPlayer();
+                    resetInProgress = true;
+                }
+                break;
+            case 2:
+                if (!resetInProgress)
+                {
+                    Debug.Log("[MotionStreamer] Received pose reset request, initiating reset...");
+                    InitiatePoseReset();
+                    Debug.Log("[MotionStreamer] Processing pose reset request.");
+                    resetInProgress = true;
+                }
+                break;
+            case 3:
+                Debug.Log("[MotionStreamer] Ping received, responding...");
+                frcDataSink.PublishValue("/questnav/miso", 97);  // 97 for ping response
+                break;
+            default:
+                if (!resetInProgress)
+                {
+                    frcDataSink.PublishValue("/questnav/miso", 0);
+                }
+                break;
+        }
     }
 
-    void InitPose()
+    private void InitiatePoseReset()
     {
-        letpositionArray = frcDataSink.GetDoubleArray("/questnav/init/position");
-        eulerAnglesArray = frcDataSink.GetDoubleArray("/questnav/init/eulerAngles");
-        
-        poseOffset.position = new Vector3((float)letpositionArray[0], (float)letpositionArray[1], (float)letpositionArray[2]);
-        Quaternion quaternion = new Quaternion((float)eulerAnglesArray[0], (float)eulerAnglesArray[1], (float)eulerAnglesArray[2], (float)eulerAnglesArray[3]);
-        poseOffset.rotation = quaternion;
-                
+        try {
+            const int maxRetries = 3;
+            const float retryDelayMs = 50f;
+
+            // FRC field boundaries in meters
+            const float FIELD_LENGTH = 16.54f;
+            const float FIELD_WIDTH = 8.02f;
+
+            double[] resetPose = null;
+            bool success = false;
+            int attemptCount = 0;
+
+            for (int i = 0; i < maxRetries && !success; i++)
+            {
+                attemptCount++;
+                if (i > 0) {
+                    System.Threading.Thread.Sleep((int)retryDelayMs);
+                    Debug.Log($"[MotionStreamer] Attempt {attemptCount} of {maxRetries}...");
+                }
+
+                Debug.Log($"[MotionStreamer] Reading NetworkTables Values (Attempt {attemptCount}):");
+
+                resetPose = frcDataSink.GetDoubleArray("/questnav/resetpose");
+
+                // Check if we got valid data
+                if (resetPose != null && resetPose.Length == 3) {
+                    // Validate field boundaries - from (0,0) to (LENGTH, WIDTH)
+                    if (resetPose[0] < 0 || resetPose[0] > FIELD_LENGTH ||
+                        resetPose[1] < 0 || resetPose[1] > FIELD_WIDTH) {
+                        Debug.LogWarning($"[MotionStreamer] Reset pose outside field boundaries: X:{resetPose[0]:F3} Y:{resetPose[1]:F3}");
+                        continue;
+                    }
+                    success = true;
+                    Debug.Log($"[MotionStreamer] Successfully read reset pose values on attempt {attemptCount}");
+                }
+
+                Debug.Log($"[MotionStreamer] Values (Attempt {attemptCount}): X:{resetPose?[0]:F3} Y:{resetPose?[1]:F3} Rot:{resetPose?[2]:F3}");
+            }
+
+            if (!success) {
+                Debug.LogWarning($"[MotionStreamer] Failed to read valid reset pose values after {attemptCount} attempts");
+                return;
+            }
+
+            double resetX = resetPose[0];
+            double resetY = resetPose[1];
+            double resetRotation = resetPose[2];
+
+            // Normalize rotation to -180 to 180 degrees
+            while (resetRotation > 180) resetRotation -= 360;
+            while (resetRotation < -180) resetRotation += 360;
+
+            // Also log MOSI value
+            long mosi = frcDataSink.GetLong("/questnav/mosi");
+            Debug.Log($"[MotionStreamer] mosi: {mosi}");
+
+            Debug.Log($"[MotionStreamer] Starting pose reset - Target: FRC X:{resetX:F2} Y:{resetY:F2} Rot:{resetRotation:F2}°");
+
+            // Store current states for reference
+            Vector3 currentCameraPos = vrCamera.position;
+            Quaternion currentCameraRot = vrCamera.rotation;
+
+            Debug.Log($"[MotionStreamer] Before reset - Camera Pos:{currentCameraPos:F3} Rot:{currentCameraRot.eulerAngles:F3}");
+
+            // 2. Convert FRC coordinates to Unity coordinates
+            Vector3 targetUnityPosition = new Vector3(
+                (float)(-resetY),        // Unity X = -FRC Y (right is positive in Unity)
+                currentCameraPos.y,      // Maintain current height
+                (float)resetX           // Unity Z = FRC X (forward is positive in both)
+            );
+
+            // 3. Calculate deltas in world space
+            Vector3 positionDelta = targetUnityPosition - currentCameraPos;
+
+            // 4. Handle rotation
+            float targetUnityYaw = (float)(-resetRotation);  // Negate because Unity is clockwise
+            float currentYaw = currentCameraRot.eulerAngles.y;
+
+            // Normalize yaw angles
+            while (currentYaw < 0) currentYaw += 360;
+            while (targetUnityYaw < 0) targetUnityYaw += 360;
+
+            float yawDelta = targetUnityYaw - currentYaw;
+            if (yawDelta > 180) yawDelta -= 360;
+            if (yawDelta < -180) yawDelta += 360;
+
+            Debug.Log($"[MotionStreamer] Calculated adjustments - Position delta:{positionDelta:F3} Rotation delta:{yawDelta:F3}°");
+            Debug.Log($"[MotionStreamer] Target Unity Position: {targetUnityPosition:F3}");
+
+            // 5. Apply transformations
+            // Store original root-to-camera offset
+            Vector3 cameraOffset = vrCamera.position - vrCameraRoot.position;
+
+            // First rotate the root
+            vrCameraRoot.RotateAround(vrCamera.position, Vector3.up, yawDelta);
+
+            // Then move the root by the required delta
+            vrCameraRoot.position += positionDelta;
+
+            // 6. Verify result
+            Debug.Log($"[MotionStreamer] After reset - Camera Pos:{vrCamera.position:F3} Rot:{vrCamera.rotation.eulerAngles:F3}");
+
+            // 7. Verify the position error
+            float posError = Vector3.Distance(vrCamera.position, targetUnityPosition);
+            Debug.Log($"[MotionStreamer] Position error after reset: {posError:F3}m");
+
+            if (posError > 0.01f) {
+                Debug.LogWarning($"[MotionStreamer] Large position error detected!");
+            }
+
+            // 8. Send success acknowledgment
+            frcDataSink.PublishValue("/questnav/miso", 98);
+        }
+        catch (Exception e) {
+            Debug.LogError($"[MotionStreamer] Error during pose reset: {e.Message}");
+            Debug.LogException(e);
+            frcDataSink.PublishValue("/questnav/miso", 0);
+            resetInProgress = false;
+        }
+    }
+
+    // Transform the HMD's rotation to virtually "zero" the robot position. Similar result as long-pressing the Oculus button.
+    void RecenterPlayer()
+    {
+        try {
+            float rotationAngleY = vrCamera.rotation.eulerAngles.y - resetTransform.rotation.eulerAngles.y;
+
+            vrCameraRoot.transform.Rotate(0, -rotationAngleY, 0);
+
+            Vector3 distanceDiff = resetTransform.position - vrCamera.position;
+            vrCameraRoot.transform.position += distanceDiff;
+
+            // Send OK value
+            frcDataSink.PublishValue("/questnav/miso", 99);
+        }
+        catch (Exception e) {
+        Debug.LogError($"[MotionStreamer] Error during pose reset: {e.Message}");
+        Debug.LogException(e);
+        frcDataSink.PublishValue("/questnav/miso", 0);
+        resetInProgress = false;
+    }
     }
 
     public void UpdateTeamNumber()
     {
-        UnityEngine.Debug.Log("[MotionStreamer] Updating Team Number");
-        // Retrieve the text from the input field
+        Debug.Log("[MotionStreamer] Updating Team Number");
         teamNumber = teamInput.text;
-
-        // Save to persistant storage
         PlayerPrefs.SetString("TeamNumber", teamNumber);
-        PlayerPrefs.Save(); // Ensure the data is written to disk
-
+        PlayerPrefs.Save();
         setInputBox(teamNumber);
-
         HandleDisconnectedState();
     }
 
     private void setInputBox(string team)
     {
-        // Clear the input field
         teamInput.text = "";
-
-        // Try to get the placeholder as a TextMeshProUGUI
         TextMeshProUGUI placeholderText = teamInput.placeholder as TextMeshProUGUI;
         if (placeholderText != null)
         {
-            // Directly set the placeholder text
             placeholderText.text = "Current: " + team;
         }
         else
         {
-            // If the placeholder is not a TextMeshProUGUI, ensure the Inspector setup is correct
             Debug.LogError("Placeholder is not assigned or not a TextMeshProUGUI component.");
         }
     }
@@ -281,15 +375,13 @@ public class MotionStreamer : MonoBehaviour
 
     private string getIP()
     {
-        // Determine the TE and AM parts
         string tePart = teamNumber.Length > 2 ? teamNumber.Substring(0, teamNumber.Length - 2) : "0";
         string amPart = teamNumber.Length > 2 ? teamNumber.Substring(teamNumber.Length - 2) : teamNumber;
-
         return serverAddress.Replace("TE", tePart).Replace("AM", amPart);
     }
 
     private void OnInputFieldSelected(string text)
     {
-        UnityEngine.Debug.Log("[MotionStreamer] Input Selected");
+        Debug.Log("[MotionStreamer] Input Selected");
     }
 }


### PR DESCRIPTION
## Made the Quest nav code more reliable and easier to work with. Main changes:

* Completely rewrote the pose reset system 
  * Now takes [X, Y, Rotation] from `/questnav/resetpose` instead of raw position/euler arrays
  * Simpler to use - just send field coordinates instead of calculating Unity transforms on RIO
  * Handles FRC -> Unity coordinate conversion properly
  * Added retry logic when reading pose data
  * Moves coordinate math to Quest - less processing on RIO
* Added field boundary checks (16.54m x 8.02m) to catch invalid poses
* Added a ping command (3) to test connection
* Better logging throughout the code
* Added XML comments/docs to everything
* Proper try/catch blocks around risky operations

## Breaking Changes

* Robot code will need to be updated to use the new pose reset format
* Old `/questnav/init/position` and `/questnav/init/eulerAngles` topics are removed
* New topic `/questnav/resetpose` expects array: [field_x, field_y, rotation_degrees]
* Much easier to use - just send the field position you want rather than calculating Unity transforms

## Notes

* Tested with various field positions including corners, center, and multiple rotations - all working correctly
* I have an example of the robot-side implementation using AdvantageKit if anyone's interested
* Keeps track of reset state better - should prevent double resets

Not super familiar with C# development so let me know if I accidentally broke something and I'll fix it!

Let me know if you run into any issues!