### PR TITLE
Add heartbeat & Prevent Zombies

### DIFF
--- a/unity/.idea/.idea.unity/.idea/.gitignore
+++ b/unity/.idea/.idea.unity/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/contentModel.xml
+/modules.xml
+/.idea.unity.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/unity/.idea/.idea.unity/.idea/encodings.xml
+++ b/unity/.idea/.idea.unity/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/unity/.idea/.idea.unity/.idea/indexLayout.xml
+++ b/unity/.idea/.idea.unity/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/unity/.idea/.idea.unity/.idea/vcs.xml
+++ b/unity/.idea/.idea.unity/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/unity/Assets/Robot/QuestNav.cs
+++ b/unity/Assets/Robot/QuestNav.cs
@@ -1,864 +1,1097 @@
-using UnityEngine;
-using NetworkTables;
-using System.Net;
-using System.Linq;
-using System.Net.Sockets;
-using TMPro;
-using UnityEngine.UI;
 using System;
-using System.Collections.Generic;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
+using NetworkTables;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
 
-/// <summary>
-/// Extension methods for Unity's Vector3 class to convert to array format.
-/// </summary>
-public static class VectorExtensions
+namespace Robot
 {
     /// <summary>
-    /// Converts a Vector3 to a float array containing x, y, and z components.
+    /// Extension methods for Unity's Vector3 class to convert to array format.
     /// </summary>
-    /// <param name="vector">The Vector3 to convert</param>
-    /// <returns>Float array containing [x, y, z] values</returns>
-    public static float[] ToArray(this Vector3 vector)
+    public static class VectorExtensions
     {
-        return new float[] { vector.x, vector.y, vector.z };
-    }
-}
-
-/// <summary>
-/// Extension methods for Unity's Quaternion class to convert to array format.
-/// </summary>
-public static class QuaternionExtensions
-{
-    /// <summary>
-    /// Converts a Quaternion to a float array containing x, y, z, and w components.
-    /// </summary>
-    /// <param name="quaternion">The Quaternion to convert</param>
-    /// <returns>Float array containing [x, y, z, w] values</returns>
-    public static float[] ToArray(this Quaternion quaternion)
-    {
-        return new float[] { quaternion.x, quaternion.y, quaternion.z, quaternion.w };
-    }
-}
-
-/// <summary>
-/// Manages streaming of VR motion data to a FRC robot through NetworkTables.
-/// Handles pose tracking, reset operations, and network communication.
-/// </summary>
-public class QuestNav : MonoBehaviour
-{
-    #region Fields
-    /// <summary>
-    /// Current frame index from Unity's Time.frameCount
-    /// </summary>
-    public int frameIndex;
-
-    /// <summary>
-    /// Current timestamp from Unity's Time.time
-    /// </summary>
-    public double timeStamp;
-
-    /// <summary>
-    /// Current position of the VR headset
-    /// </summary>
-    public Vector3 position;
-
-    /// <summary>
-    /// Current rotation of the VR headset as a Quaternion
-    /// </summary>
-    public Quaternion rotation;
-
-    /// <summary>
-    /// Current rotation of the VR headset in Euler angles
-    /// </summary>
-    public Vector3 eulerAngles;
-
-    /// <summary>
-    /// Reference to the OVR Camera Rig for tracking
-    /// </summary>
-    public OVRCameraRig cameraRig;
-
-    /// <summary>
-    /// NetworkTables connection for FRC data communication
-    /// </summary>
-    public Nt4Source frcDataSink = null;
-
-    /// <summary>
-    /// Current command received from the robot
-    /// </summary>
-    private long command = 0;
-
-    /// <summary>
-    /// Flag indicating if a reset operation is in progress
-    /// </summary>
-    private bool resetInProgress = false;
-
-    /// <summary>
-    /// Input field for team number entry
-    /// </summary>
-    public TMP_InputField teamInput;
-
-    // <summary>
-    /// IP address text
-    /// </summary>
-    public TMP_Text ipAddressText;
-
-    // <summary>
-    /// ConState text
-    /// </summary>
-    public TMP_Text conStateText;
-
-    /// <summary>
-    /// Current log message
-    /// </summary>
-    private string conStateMessage = "No Message";
-
-    /// <summary>
-    /// Button to update team number
-    /// </summary>
-    public Button teamUpdateButton;
-
-    /// <summary>
-    /// Default team number text
-    /// </summary>
-    public static string inputText = "9999";
-
-    /// <summary>
-    /// Current team number
-    /// </summary>
-    private string teamNumber = "";
-
-    /// <summary>
-    /// Reference to the VR camera transform
-    /// </summary>
-    [SerializeField] 
-    public Transform vrCamera;
-
-    /// <summary>
-    /// Reference to the VR camera root transform
-    /// </summary>
-    [SerializeField] 
-    public Transform vrCameraRoot;
-
-    /// <summary>
-    /// Reference to the reset position transform
-    /// </summary>
-    [SerializeField] 
-    public Transform resetTransform;
-
-    /// <summary>
-    /// Current battery percentage of the device
-    /// </summary>
-    private float batteryPercent = 0;
-
-    #region NetworkTables Configuration
-    /// <summary>
-    /// Application name for NetworkTables connection
-    /// </summary>
-    private readonly string appName = "QuestNav";
-
-    /// <summary>
-    /// Server address format for NetworkTables connection
-    /// </summary>
-    private readonly string serverAddress = "10.TE.AM.2";
-
-    /// <summary>
-    /// Current IP address for connection
-    /// </summary>
-    private string ipAddress = "";
-
-    /// <summary>
-    /// NetworkTables server port
-    /// </summary>
-    private readonly int serverPort = 5810;
-
-    /// <summary>
-    /// Counter for connection retry delay
-    /// </summary>
-    private int delayCounter = 0;
-
-    /// <summary>
-    /// Quest display frequency (in Hz)
-    /// </summary>
-    private float displayFrequency = 120.0f;
-
-    /// <summary>
-    /// Holds the detected local IP address of the HMD
-    /// </summary>
-    private string myAddressLocal = "0.0.0.0";
-
-    /// <summary>
-    /// Default reconnect delay for failed connection attempts
-    /// </summary>
-    private float defaultReconnectDelay = 3.0f; //seconds
-
-    /// <summary>
-    /// Reconnection delay variable for delaying failed connection attempts.
-    /// This value changes dynamically based on the number of failed attempts.
-    /// </summary>
-    private float reconnectDelay = 3.0f; //seconds
-
-    /// <summary>
-    /// Maximum reconnection delay (rate limited to prevent excessive retries lagging the main Unity thread)
-    /// </summary>
-    private const float maxReconnectDelay = 10.0f; //seconds
-
-    /// <summary>
-    /// List of failed connection attempt candidates (prevents excessive retries on failed addresses)
-    /// </summary>
-    private Dictionary<string, float> failedCandidates = new Dictionary<string, float>();
-
-    /// <summary>
-    /// Unreachable network delay
-    /// </summary>
-    private int unreachableNetworkDelay = 5; // seconds
-
-    /// <summary>
-    /// Cooldown before trying candidates that have failed previously
-    /// </summary>
-    private const float candidateFailureCooldown = 10.0f; // seconds
-
-    /// <summary>
-    /// Coroutine definition to enable controlling the connection process
-    /// </summary>
-    private Coroutine _connectionCoroutine;
-
-    /// <summary>
-    /// used to only set up the coroutine once in async
-    /// </summary>
-    private bool connectionAttempt = false;
-
-    /// <summary>
-    /// used to make sure connection completed on coroutine
-    /// </summary>
-    private bool connectionAttemptCompleted = true;
-
-
-    #endregion
-
-    #region Unity Lifecycle Methods
-    /// <summary>
-    /// Initializes the connection and UI components
-    /// </summary>
-    void Start()
-    {
-        OVRPlugin.systemDisplayFrequency = displayFrequency;
-        teamNumber = PlayerPrefs.GetString("TeamNumber", "9999");
-        setInputBox(teamNumber);
-        teamInput.Select();
-        UpdateIPAddressText();
-        UpdateConStateText();
-        ConnectToRobot();
-        teamUpdateButton.onClick.AddListener(UpdateTeamNumber);
-        teamInput.onSelect.AddListener(OnInputFieldSelected);
+        /// <summary>
+        /// Converts a Vector3 to a float array containing x, y, and z components.
+        /// </summary>
+        /// <param name="vector">The Vector3 to convert</param>
+        /// <returns>Float array containing [x, y, z] values</returns>
+        public static float[] ToArray(this Vector3 vector)
+        {
+            return new float[] { vector.x, vector.y, vector.z };
+        }
     }
 
     /// <summary>
-    /// Handles frame updates for data publishing and command processing
+    /// Extension methods for Unity's Quaternion class to convert to array format.
     /// </summary>
-    void LateUpdate()
+    public static class QuaternionExtensions
     {
-        // If the connection isn’t ready, skip the update.
-        if (frcDataSink == null || !frcDataSink.Client.Connected())
+        /// <summary>
+        /// Converts a Quaternion to a float array containing x, y, z, and w components.
+        /// </summary>
+        /// <param name="quaternion">The Quaternion to convert</param>
+        /// <returns>Float array containing [x, y, z, w] values</returns>
+        public static float[] ToArray(this Quaternion quaternion)
         {
-            conStateMessage = "datasink null not connected";
-            UpdateConStateText();
-
-            if(!frcDataSink.Client.Connected() )
-            {
-                conStateMessage = "handling disconnected state";
-                UpdateConStateText();
-
-                // hitting the async handler repeatedly seems to cause issues
-                //  seeing multpile nt connections
-                //  need to do this once per attempt
-                // this bool is set to true in connect to robot
-                if( connectionAttempt == true )
-                {
-                    conStateMessage = "conn atmpt in progress";
-                    UpdateConStateText();
-                }
-                else
-                {
-                    HandleDisconnectedState();
-                }
-                
-            }
-
-            // add a null handler here too?
-
-            return;
+            return new float[] { quaternion.x, quaternion.y, quaternion.z, quaternion.w };
         }
+    }
 
-        if (frcDataSink.Client.Connected())
+    /// <summary>
+    /// Manages streaming of VR motion data to a FRC robot through NetworkTables.
+    /// Handles pose tracking, reset operations, and network communication.
+    /// </summary>
+    public class QuestNav : MonoBehaviour
+    {
+        #region Fields
+        /// <summary>
+        /// Current frame index from Unity's Time.frameCount
+        /// </summary>
+        public int frameIndex;
+
+        /// <summary>
+        /// Current timestamp from Unity's Time.time
+        /// </summary>
+        public double timeStamp;
+
+        /// <summary>
+        /// Current position of the VR headset
+        /// </summary>
+        public Vector3 position;
+
+        /// <summary>
+        /// Current rotation of the VR headset as a Quaternion
+        /// </summary>
+        public Quaternion rotation;
+
+        /// <summary>
+        /// Current rotation of the VR headset in Euler angles
+        /// </summary>
+        public Vector3 eulerAngles;
+
+        /// <summary>
+        /// Reference to the OVR Camera Rig for tracking
+        /// </summary>
+        public OVRCameraRig cameraRig;
+
+        /// <summary>
+        /// NetworkTables connection for FRC data communication
+        /// </summary>
+        public Nt4Source frcDataSink = null;
+
+        /// <summary>
+        /// Current command received from the robot
+        /// </summary>
+        private long command = 0;
+
+        /// <summary>
+        /// Flag indicating if a reset operation is in progress
+        /// </summary>
+        private bool resetInProgress = false;
+
+        /// <summary>
+        /// Input field for team number entry
+        /// </summary>
+        public TMP_InputField teamInput;
+
+        // <summary>
+        /// IP address text
+        /// </summary>
+        public TMP_Text ipAddressText;
+
+        // <summary>
+        /// ConState text
+        /// </summary>
+        public TMP_Text conStateText;
+
+        /// <summary>
+        /// Current log message
+        /// </summary>
+        private string conStateMessage = "No Message";
+
+        /// <summary>
+        /// Button to update team number
+        /// </summary>
+        public Button teamUpdateButton;
+
+        /// <summary>
+        /// Default team number text
+        /// </summary>
+        public static string inputText = "9999";
+
+        /// <summary>
+        /// Current team number
+        /// </summary>
+        private string teamNumber = "";
+
+        /// <summary>
+        /// Reference to the VR camera transform
+        /// </summary>
+        [SerializeField] 
+        public Transform vrCamera;
+
+        /// <summary>
+        /// Reference to the VR camera root transform
+        /// </summary>
+        [SerializeField] 
+        public Transform vrCameraRoot;
+
+        /// <summary>
+        /// Reference to the reset position transform
+        /// </summary>
+        [SerializeField] 
+        public Transform resetTransform;
+
+        /// <summary>
+        /// Current battery percentage of the device
+        /// </summary>
+        private float batteryPercent = 0;
+
+        #region NetworkTables Configuration
+        /// <summary>
+        /// Application name for NetworkTables connection
+        /// </summary>
+        private readonly string appName = "QuestNav";
+
+        /// <summary>
+        /// Server address format for NetworkTables connection
+        /// </summary>
+        private readonly string serverAddress = "10.TE.AM.2";
+
+        /// <summary>
+        /// Current IP address for connection
+        /// </summary>
+        private string ipAddress = "";
+
+        /// <summary>
+        /// NetworkTables server port
+        /// </summary>
+        private readonly int serverPort = 5810;
+
+        /// <summary>
+        /// Counter for connection retry delay
+        /// </summary>
+        private int delayCounter = 0;
+
+        /// <summary>
+        /// Quest display frequency (in Hz)
+        /// </summary>
+        private float displayFrequency = 120.0f;
+
+        /// <summary>
+        /// Holds the detected local IP address of the HMD
+        /// </summary>
+        private string myAddressLocal = "0.0.0.0";
+
+        /// <summary>
+        /// Default reconnect delay for failed connection attempts
+        /// </summary>
+        private float defaultReconnectDelay = 3.0f; //seconds
+
+        /// <summary>
+        /// Reconnection delay variable for delaying failed connection attempts.
+        /// This value changes dynamically based on the number of failed attempts.
+        /// </summary>
+        private float reconnectDelay = 3.0f; //seconds
+
+        /// <summary>
+        /// Maximum reconnection delay (rate limited to prevent excessive retries lagging the main Unity thread)
+        /// </summary>
+        private const float maxReconnectDelay = 10.0f; //seconds
+
+        /// <summary>
+        /// List of failed connection attempt candidates (prevents excessive retries on failed addresses)
+        /// </summary>
+        private Dictionary<string, float> failedCandidates = new Dictionary<string, float>();
+
+        /// <summary>
+        /// Unreachable network delay
+        /// </summary>
+        private int unreachableNetworkDelay = 5; // seconds
+
+        /// <summary>
+        /// Cooldown before trying candidates that have failed previously
+        /// </summary>
+        private const float candidateFailureCooldown = 10.0f; // seconds
+
+        /// <summary>
+        /// Coroutine definition to enable controlling the connection process
+        /// </summary>
+        private Coroutine _connectionCoroutine;
+
+        /// <summary>
+        /// used to only set up the coroutine once in async
+        /// </summary>
+        private bool connectionAttempt = false;
+
+        /// <summary>
+        /// used to make sure connection completed on coroutine
+        /// </summary>
+        private bool connectionAttemptCompleted = true;
+
+        /// <summary>
+        /// Timestamp when the connection attempt started for timeout calculation
+        /// </summary>
+        private float connectionAttemptStartTime = 0;
+
+        /// <summary>
+        /// Maximum time to wait for a connection attempt before resetting state
+        /// </summary>
+        private const float CONNECTION_ATTEMPT_TIMEOUT = 10.0f; // seconds
+
+        #endregion
+
+        #region Heartbeat System
+        /// <summary>
+        /// Heartbeat counter value that increments with each successful exchange
+        /// </summary>
+        private int heartbeatCounter = 1;
+
+        /// <summary>
+        /// Time when the last heartbeat was sent to the robot
+        /// </summary>
+        private float lastHeartbeatSentTime = 0;
+
+        /// <summary>
+        /// Time when the last successful heartbeat response was received
+        /// </summary>
+        private float lastHeartbeatResponseTime = 0;
+
+        /// <summary>
+        /// Flag indicating whether we're waiting for a heartbeat response
+        /// </summary>
+        private bool heartbeatResponsePending = false;
+
+        /// <summary>
+        /// Counter for consecutive failed heartbeats
+        /// </summary>
+        private int consecutiveFailedHeartbeats = 0;
+
+        /// <summary>
+        /// Maximum number of consecutive heartbeat failures before forcing reconnection
+        /// </summary>
+        private const int MAX_FAILED_HEARTBEATS = 3;
+
+        /// <summary>
+        /// Time interval between heartbeat checks (seconds)
+        /// </summary>
+        private const float HEARTBEAT_INTERVAL = 1.0f;
+
+        /// <summary>
+        /// Maximum time to wait for a heartbeat response before considering it failed (seconds)
+        /// </summary>
+        private const float HEARTBEAT_TIMEOUT = 3.0f;
+        #endregion
+
+        #region Unity Lifecycle Methods
+        /// <summary>
+        /// Initializes the connection and UI components
+        /// </summary>
+        void Start()
         {
-            conStateMessage = "connected sending data";
-            PublishFrameData();
-            ProcessCommands();
-        }
-        else
-        {
-
-            // the two recovery states should be handled above in null and not conected
-
-            conStateMessage = "not disconnected or connected";
-            
-            // hitting the async handler repeatedly seems to cause issues
-            //  seeing multpile nt connections
-
-            // HandleDisconnectedState();
-
-        }
-
-        // Only execute these functions once per second
-        if (delayCounter >= (int)displayFrequency)
-        {
+            OVRPlugin.systemDisplayFrequency = displayFrequency;
+            teamNumber = PlayerPrefs.GetString("TeamNumber", "9999");
+            setInputBox(teamNumber);
+            teamInput.Select();
             UpdateIPAddressText();
             UpdateConStateText();
-            delayCounter = 0;
+            ConnectToRobot();
+            teamUpdateButton.onClick.AddListener(UpdateTeamNumber);
+            teamInput.onSelect.AddListener(OnInputFieldSelected);
         }
-        else
-        {
-            delayCounter++;
-        }
-    }
-    #endregion
-    #endregion
 
-    #region Network Connection Methods
-    /// <summary>
-    /// Called to start the connection process.
-    /// </summary>
-    private void ConnectToRobot()
-    {
-        connectionAttempt = true;
-        connectionAttemptCompleted = false;
-        StartCoroutine(ConnectionCoroutineWrapper());
-    }
-
-    /// <summary>
-    /// A coroutine wrapper that waits until the asynchronous connection method completes.
-    /// This wrapper enables setting timeout guardbands for the connection process.
-    /// </summary>
-    private IEnumerator ConnectionCoroutineWrapper()
-    {
-        var connectionTask = AttemptConnectionAsync();
-        while (!connectionTask.IsCompleted)
+        /// <summary>
+        /// Handles frame updates for data publishing and command processing
+        /// </summary>
+        void LateUpdate()
         {
-            yield return null;
-        }
-    }
-
-    /// <summary>
-    /// Asynchronously attempts to connect to one of the candidate addresses.
-    /// Uses async DNS resolution and wraps blocking calls in Task.Run to avoid blocking the main Unity thread.
-    /// </summary>
-    private async Task AttemptConnectionAsync()
-    {
-        bool connectionEstablished = false;
-        List<string> candidateAddresses = new List<string>()
-        {
-            generateIP(),
-            "172.22.11.2",
-            $"roboRIO-{teamNumber}-FRC.local",
-            $"roboRIO-{teamNumber}-FRC.lan",
-            $"roboRIO-{teamNumber}-FRC.frc-field.local"
-        };
-
-        while (!connectionEstablished)
-        {
-            // Check if the network is reachable.
-            if (Application.internetReachability == NetworkReachability.NotReachable)
-            {
-                QueuedLogger.LogWarning($"[QuestNav] Network not reachable. Waiting {unreachableNetworkDelay} seconds before reattempting.");
-                conStateMessage = "net no reach waiting";
-                await Task.Delay(unreachableNetworkDelay);
-                continue;
+            // Check for connection attempt timeout to prevent zombie state
+            if (connectionAttempt && (Time.time - connectionAttemptStartTime > CONNECTION_ATTEMPT_TIMEOUT)) {
+                QueuedLogger.LogWarning("[QuestNav] Connection attempt timed out, resetting state");
+                connectionAttempt = false;
+                conStateMessage = "Connection attempt timed out, retry enabled";
+                UpdateConStateText();
             }
 
-            StringBuilder cycleLog = new StringBuilder();
-            cycleLog.AppendLine("[QuestNav] Connection attempt cycle:");
-            conStateMessage = "connection attempt cycle";
-
-            foreach (string candidate in candidateAddresses)
+            // If the connection isn't ready, attempt to reconnect
+            if (frcDataSink == null || !frcDataSink.Client.Connected())
             {
-                // Skip a candidate if it failed recently.
-                if (failedCandidates.ContainsKey(candidate) && (Time.time - failedCandidates[candidate] < candidateFailureCooldown))
+                conStateMessage = frcDataSink == null ? "datasink null" : "not connected";
+                UpdateConStateText();
+
+                // Only start a new connection attempt if not already trying
+                if (!connectionAttempt)
                 {
-                    cycleLog.AppendLine($"Skipping candidate {candidate} (failed less than {candidateFailureCooldown} seconds ago).");
-                    conStateMessage = "skipping " + candidate + " cool " + candidateFailureCooldown;
-                    continue;
+                    conStateMessage = "initiating reconnection";
+                    UpdateConStateText();
+                    HandleDisconnectedState();
                 }
                 else
                 {
-                    failedCandidates.Remove(candidate);
-                    conStateMessage = "removed candidate " + candidate;
+                    conStateMessage = "connection attempt in progress";
+                    UpdateConStateText();
                 }
-
-                string resolvedAddress = candidate;
-                try
-                {
-                    // Use asynchronous DNS resolution.
-                    IPHostEntry hostEntry = await Dns.GetHostEntryAsync(candidate);
-                    IPAddress[] ipv4Addresses = hostEntry.AddressList
-                        .Where(ip => ip.AddressFamily == AddressFamily.InterNetwork)
-                        .ToArray();
-                    if (ipv4Addresses.Length > 0)
-                    {
-                        resolvedAddress = ipv4Addresses[0].ToString();
-                    }
-                    else
-                    {
-                        cycleLog.AppendLine($"DNS lookup returned no IPv4 for candidate '{candidate}'.");
-                        conStateMessage = "no ipv4 for " + candidate;
-                        failedCandidates[candidate] = Time.time;
-                        continue;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    cycleLog.AppendLine($"DNS resolution failed for candidate '{candidate}': {ex.Message}");
-                    conStateMessage = "dns failed for " + candidate;
-                    failedCandidates[candidate] = Time.time;
-                    continue;
-                }
-
-                cycleLog.AppendLine($"Attempting connection to {resolvedAddress}...");
-                conStateMessage = "attempting " + resolvedAddress;
-
-                try
-                {
-                    // Wrap the potentially blocking connection call in Task.Run.
-                    var sink = await Task.Run(() =>
-                    {
-                        return new Nt4Source(appName, resolvedAddress, serverPort);
-                    });
-
-                    if (sink.Client.Connected())
-                    {
-                        ipAddress = resolvedAddress; // Cache the working address.
-                        frcDataSink = sink;
-                        cycleLog.AppendLine($"Connected successfully to {resolvedAddress}.");
-                        conStateMessage = "connected to " + resolvedAddress;
-                        connectionEstablished = true;
-                        connectionAttempt = false;
-                        connectionAttemptCompleted = true;
-                        break;
-                    }
-                    else
-                    {
-                        cycleLog.AppendLine($"Connection attempt to {resolvedAddress} did not succeed.");
-                        conStateMessage = "conn failed to " + resolvedAddress;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    cycleLog.AppendLine($"Connection attempt failed for {resolvedAddress}: {ex.Message}");
-                    conStateMessage = "conn failed " + resolvedAddress + " " + ex.Message;
-                }
-            }
-
-            // Handle a failed connection
-            if (!connectionEstablished)
-            {
-                cycleLog.AppendLine($"Could not establish a connection with any candidate addresses. Reattempting in {reconnectDelay} second(s)...");
-                conStateMessage = "no conn to any candidates trying in " + reconnectDelay;
-                QueuedLogger.Log(cycleLog.ToString(), QueuedLogger.LogLevel.Warning);
-                await Task.Delay((int)(reconnectDelay * 1000));
-                reconnectDelay = Mathf.Min(reconnectDelay * 2, maxReconnectDelay);
-            }
-        }
-
-        // Reset delay on success.
-        reconnectDelay = defaultReconnectDelay;
-        QueuedLogger.Log("[QuestNav] Connection established. Publishing topics.");
-        conStateMessage = "connected - publishing";
-        PublishTopics();
-    }
-
-    /// <summary>
-    /// Handles reconnection when connection is lost
-    /// </summary>
-    private void HandleDisconnectedState()
-    {
-        QueuedLogger.Log("[QuestNav] Robot disconnected. Resetting connection and attempting to reconnect...");
-        conStateMessage = "robot disconnected - retrying";
-        frcDataSink.Client.Disconnect();
-        ConnectToRobot();
-    }
-
-    /// <summary>
-    /// Publishes and subscribes to required NetworkTables topics
-    /// </summary>
-    private void PublishTopics()
-    {
-        frcDataSink.PublishTopic("/questnav/miso", "int");
-        frcDataSink.PublishTopic("/questnav/frameCount", "int");
-        frcDataSink.PublishTopic("/questnav/timestamp", "double");
-        frcDataSink.PublishTopic("/questnav/position", "float[]");
-        frcDataSink.PublishTopic("/questnav/quaternion", "float[]");
-        frcDataSink.PublishTopic("/questnav/eulerAngles", "float[]");
-        frcDataSink.PublishTopic("/questnav/batteryPercent", "double");
-        frcDataSink.Subscribe("/questnav/mosi", 0.1, false, false, false);
-        frcDataSink.Subscribe("/questnav/init/position", 0.1, false, false, false);
-        frcDataSink.Subscribe("/questnav/init/eulerAngles", 0.1, false, false, false);
-        frcDataSink.Subscribe("/questnav/resetpose", 0.1, false, false, false);
-    }
-    #endregion
-
-    #region Data Publishing Methods
-    /// <summary>
-    /// Publishes current frame data to NetworkTables
-    /// </summary>
-    private void PublishFrameData()
-    {
-        frameIndex = Time.frameCount;
-        timeStamp = Time.time;
-        position = cameraRig.centerEyeAnchor.position;
-        rotation = cameraRig.centerEyeAnchor.rotation;
-        eulerAngles = cameraRig.centerEyeAnchor.eulerAngles;
-        batteryPercent = SystemInfo.batteryLevel * 100;
-
-        frcDataSink.PublishValue("/questnav/frameCount", frameIndex);
-        frcDataSink.PublishValue("/questnav/timestamp", timeStamp);
-        frcDataSink.PublishValue("/questnav/position", position.ToArray());
-        frcDataSink.PublishValue("/questnav/quaternion", rotation.ToArray());
-        frcDataSink.PublishValue("/questnav/eulerAngles", eulerAngles.ToArray());
-        frcDataSink.PublishValue("/questnav/batteryPercent", batteryPercent);
-    }
-    #endregion
-
-    #region Command Processing Methods
-    /// <summary>
-    /// Processes commands received from the robot
-    /// </summary>
-    private void ProcessCommands()
-    {
-        command = frcDataSink.GetLong("/questnav/mosi");
-
-        if (resetInProgress && command == 0)
-        {
-            resetInProgress = false;
-            QueuedLogger.Log("[QuestNav] Reset operation completed");
-            return;
-        }
-
-        switch (command)
-        {
-            case 1:
-                if (!resetInProgress)
-                {
-                    QueuedLogger.Log("[QuestNav] Received heading reset request, initiating recenter...");
-                    RecenterPlayer();
-                    resetInProgress = true;
-                }
-                break;
-            case 2:
-                if (!resetInProgress)
-                {
-                    QueuedLogger.Log("[QuestNav] Received pose reset request, initiating reset...");
-                    InitiatePoseReset();
-                    QueuedLogger.Log("[QuestNav] Processing pose reset request.");
-                    resetInProgress = true;
-                }
-                break;
-            case 3:
-                QueuedLogger.Log("[QuestNav] Ping received, responding...");
-                frcDataSink.PublishValue("/questnav/miso", 97);  // 97 for ping response
-                break;
-            default:
-                if (!resetInProgress)
-                {
-                    frcDataSink.PublishValue("/questnav/miso", 0);
-                }
-                break;
-        }
-    }
-
-    /// <summary>
-    /// Initiates a pose reset based on received NetworkTables data
-    /// </summary>
-    private void InitiatePoseReset()
-    {
-        try {
-            // Constants for retry logic and field dimensions
-            const int maxRetries = 3;              // Maximum number of attempts to read pose data
-            const float retryDelayMs = 50f;        // Delay between retry attempts
-            const float FIELD_LENGTH = 16.54f;     // FRC field length in meters
-            const float FIELD_WIDTH = 8.02f;       // FRC field width in meters
-
-            double[] resetPose = null;
-            bool success = false;
-            int attemptCount = 0;
-
-            // Attempt to read pose data from NetworkTables with retry logic
-            for (int i = 0; i < maxRetries && !success; i++)
-            {
-                attemptCount++;
-                // Add delay between retries to allow for network latency
-                if (i > 0) {
-                    System.Threading.Thread.Sleep((int)retryDelayMs);
-                    QueuedLogger.Log($"[QuestNav] Attempt {attemptCount} of {maxRetries}...");
-                }
-
-                QueuedLogger.Log($"[QuestNav] Reading NetworkTables Values (Attempt {attemptCount}):");
-
-                // Read the pose array from NetworkTables
-                // Format: [X, Y, Rotation] in FRC field coordinates
-                resetPose = frcDataSink.GetDoubleArray("/questnav/resetpose");
-
-                // Validate pose data format and field boundaries
-                if (resetPose != null && resetPose.Length == 3) {
-                    // Check if pose is within valid field boundaries
-                    if (resetPose[0] < 0 || resetPose[0] > FIELD_LENGTH ||
-                        resetPose[1] < 0 || resetPose[1] > FIELD_WIDTH) {
-                        QueuedLogger.LogWarning($"[QuestNav] Reset pose outside field boundaries: X:{resetPose[0]:F3} Y:{resetPose[1]:F3}");
-                        continue;
-                    }
-                    success = true;
-                    QueuedLogger.Log($"[QuestNav] Successfully read reset pose values on attempt {attemptCount}");
-                }
-
-                QueuedLogger.Log($"[QuestNav] Values (Attempt {attemptCount}): X:{resetPose?[0]:F3} Y:{resetPose?[1]:F3} Rot:{resetPose?[2]:F3}");
-            }
-
-            // Exit if we couldn't get valid pose data
-            if (!success) {
-                QueuedLogger.LogWarning($"[QuestNav] Failed to read valid reset pose values after {attemptCount} attempts");
                 return;
             }
 
-            // Extract pose components from the array
-            double resetX = resetPose[0];          // FRC X coordinate (along length of field)
-            double resetY = resetPose[1];          // FRC Y coordinate (along width of field)
-            double resetRotation = resetPose[2];   // FRC rotation (CCW positive)
-
-            // Normalize rotation to -180 to 180 degrees range
-            while (resetRotation > 180) resetRotation -= 360;
-            while (resetRotation < -180) resetRotation += 360;
-
-            QueuedLogger.Log($"[QuestNav] Starting pose reset - Target: FRC X:{resetX:F2} Y:{resetY:F2} Rot:{resetRotation:F2}°");
-
-            // Store current VR camera state for reference
-            Vector3 currentCameraPos = vrCamera.position;
-            Quaternion currentCameraRot = vrCamera.rotation;
-
-            QueuedLogger.Log($"[QuestNav] Before reset - Camera Pos:{currentCameraPos:F3} Rot:{currentCameraRot.eulerAngles:F3}");
-
-            // Convert FRC coordinates to Unity coordinates:
-            // Unity uses a left-handed coordinate system with Y as the vertical axis (aligned with gravity)
-            // FRC uses a right-handed coordinate system with Z as the vertical axis (aligned with gravity)
-            // See this page for more Unity details: https://docs.unity3d.com/Manual/QuaternionAndEulerRotationsInUnity.html
-            // See this page for more FRC details: https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html
-
-            // - Unity X = -FRC Y (right is positive in Unity)
-            // - Unity Y = kept unchanged (height)
-            // - Unity Z = FRC X (forward is positive in both)
-            Vector3 targetUnityPosition = new Vector3(
-                (float)(-resetY),         // Negate Y for Unity's coordinate system
-                currentCameraPos.y,       // Maintain current height
-                (float)resetX            // FRC X maps directly to Unity Z
-            );
-
-            // Calculate the position difference we need to move
-            Vector3 positionDelta = targetUnityPosition - currentCameraPos;
-
-            // Convert FRC rotation to Unity rotation:
-            // - Unity uses clockwise positive rotation around Y
-            // - FRC uses counterclockwise positive rotation
-            float targetUnityYaw = (float)(-resetRotation);  // Negate for Unity's rotation direction
-            float currentYaw = currentCameraRot.eulerAngles.y;
-
-            // Normalize both angles to 0-360 range for proper delta calculation
-            while (currentYaw < 0) currentYaw += 360;
-            while (targetUnityYaw < 0) targetUnityYaw += 360;
-
-            // Calculate rotation delta and normalize to -180 to 180 range
-            float yawDelta = targetUnityYaw - currentYaw;
-            if (yawDelta > 180) yawDelta -= 360;
-            if (yawDelta < -180) yawDelta += 360;
-
-            QueuedLogger.Log($"[QuestNav] Calculated adjustments - Position delta:{positionDelta:F3} Rotation delta:{yawDelta:F3}°");
-            QueuedLogger.Log($"[QuestNav] Target Unity Position: {targetUnityPosition:F3}");
-
-            // Store the original offset between camera and its root
-            // This helps maintain proper VR tracking space
-            Vector3 cameraOffset = vrCamera.position - vrCameraRoot.position;
-
-            // First rotate the root around the camera position
-            // This maintains the camera's position while changing orientation
-            vrCameraRoot.RotateAround(vrCamera.position, Vector3.up, yawDelta);
-
-            // Then apply the position adjustment to achieve target position
-            vrCameraRoot.position += positionDelta;
-
-            // Log final position and rotation for verification
-            QueuedLogger.Log($"[QuestNav] After reset - Camera Pos:{vrCamera.position:F3} Rot:{vrCamera.rotation.eulerAngles:F3}");
-
-            // Calculate and check position error to ensure accuracy
-            float posError = Vector3.Distance(vrCamera.position, targetUnityPosition);
-            QueuedLogger.Log($"[QuestNav] Position error after reset: {posError:F3}m");
-
-            // Warn if position error is larger than expected threshold
-            if (posError > 0.01f) {  // 1cm threshold
-                QueuedLogger.LogWarning($"[QuestNav] Large position error detected!");
-            }
-
-            frcDataSink.PublishValue("/questnav/miso", 98);
-        }
-        catch (Exception e) {
-            QueuedLogger.LogError($"[QuestNav] Error during pose reset: {e.Message}");
-            QueuedLogger.LogException(e);
-            frcDataSink.PublishValue("/questnav/miso", 0);
-            resetInProgress = false;
-        }
-    }
-
-    /// <summary>
-    /// Recenters the player's view by adjusting the VR camera root transform to match the reset transform.
-    /// Similar to the effect of long-pressing the Oculus button.
-    /// </summary>
-    void RecenterPlayer()
-    {
-        try {
-            float rotationAngleY = vrCamera.rotation.eulerAngles.y - resetTransform.rotation.eulerAngles.y;
-
-            vrCameraRoot.transform.Rotate(0, -rotationAngleY, 0);
-
-            Vector3 distanceDiff = resetTransform.position - vrCamera.position;
-            vrCameraRoot.transform.position += distanceDiff;
-
-            frcDataSink.PublishValue("/questnav/miso", 99);
-        }
-        catch (Exception e) {
-            QueuedLogger.LogError($"[QuestNav] Error during pose reset: {e.Message}");
-            QueuedLogger.LogException(e);
-            frcDataSink.PublishValue("/questnav/miso", 0);
-            resetInProgress = false;
-        }
-    }
-    #endregion
-
-    #region UI Methods
-    /// <summary>
-    /// Updates the team number based on user input and triggers an asynchronous connection reset.
-    /// </summary>
-    public void UpdateTeamNumber()
-    {
-        QueuedLogger.Log("[QuestNav] Updating Team Number");
-        teamNumber = teamInput.text;
-        PlayerPrefs.SetString("TeamNumber", teamNumber);
-        PlayerPrefs.Save();
-        setInputBox(teamNumber);
-
-        // Clear cached IP and candidate failure data.
-        ipAddress = "";
-        failedCandidates.Clear();
-
-        // If a connection coroutine is already running, stop it.
-        if (_connectionCoroutine != null)
-        {
-            StopCoroutine(_connectionCoroutine);
-            _connectionCoroutine = null;
-        }
-
-        // Disconnect existing connection, if any.
-        if (frcDataSink != null)
-        {
+            // Connected - manage heartbeat, publish data, and process commands
             if (frcDataSink.Client.Connected())
             {
-                frcDataSink.Client.Disconnect();
+                conStateMessage = "connected - sending data";
+                
+                // Manage heartbeat to detect zombie connections
+                ManageHeartbeat();
+                
+                // Regular data processing
+                PublishFrameData();
+                ProcessCommands();
             }
-            frcDataSink = null;
-        }
 
-        // Restart the asynchronous connection process.
-        _connectionCoroutine = StartCoroutine(ConnectionCoroutineWrapper());
-    }
-
-    /// <summary>
-    /// Updates the default IP address shown in the UI with the current HMD IP address
-    /// </summary>
-    /// 
-    public void UpdateIPAddressText()
-    {
-        //Get the local IP
-        IPHostEntry hostEntry = Dns.GetHostEntry(Dns.GetHostName());
-        foreach (IPAddress ip in hostEntry.AddressList)
-        {
-            if (ip.AddressFamily == AddressFamily.InterNetwork)
+            // Update UI periodically
+            if (delayCounter >= (int)displayFrequency)
             {
-                myAddressLocal = ip.ToString();
-                TextMeshProUGUI ipText = ipAddressText as TextMeshProUGUI;
-                if (myAddressLocal == "127.0.0.1")
+                UpdateIPAddressText();
+                UpdateConStateText();
+                delayCounter = 0;
+            }
+            else
+            {
+                delayCounter++;
+            }
+        }
+        #endregion
+        #endregion
+
+        #region Heartbeat System Methods
+        /// <summary>
+        /// Manages the heartbeat system to detect zombie connections.
+        /// Called in LateUpdate when connection is established.
+        /// </summary>
+        private void ManageHeartbeat()
+        {
+            // Only run if connected
+            if (frcDataSink == null || !frcDataSink.Client.Connected()) return;
+            
+            float currentTime = Time.time;
+            
+            // Check if previous heartbeat timed out
+            if (heartbeatResponsePending)
+            {
+                if (currentTime - lastHeartbeatSentTime > HEARTBEAT_TIMEOUT)
                 {
-                    ipText.text = "No Adapter Found";
+                    // Heartbeat timed out - increment failure counter
+                    consecutiveFailedHeartbeats++;
+                    heartbeatResponsePending = false;
+                    QueuedLogger.LogWarning($"[QuestNav] Heartbeat #{heartbeatCounter} timed out. Failed count: {consecutiveFailedHeartbeats}");
+                    
+                    // Force reconnection if too many consecutive failures
+                    if (consecutiveFailedHeartbeats >= MAX_FAILED_HEARTBEATS)
+                    {
+                        QueuedLogger.LogWarning("[QuestNav] Too many failed heartbeats, forcing reconnection");
+                        ForceReconnection();
+                        return;
+                    }
                 }
                 else
                 {
-                    ipText.text = myAddressLocal;
+                    // Check for heartbeat response if still waiting
+                    CheckHeartbeatResponse();
                 }
             }
-            break;
+            
+            // Send new heartbeat if interval elapsed and not waiting for response
+            if (!heartbeatResponsePending && currentTime - lastHeartbeatSentTime > HEARTBEAT_INTERVAL)
+            {
+                SendHeartbeat();
+            }
         }
-    }
 
-    public void UpdateConStateText()
-    {
-
-        TextMeshProUGUI conText = conStateText as TextMeshProUGUI;
-        conText.text = conStateMessage;
-    
-    }
-
-
-    /// <summary>
-    /// Updates the input box placeholder text with the current team number
-    /// </summary>
-    /// <param name="team">The team number to display</param>
-    private void setInputBox(string team)
-    {
-        teamInput.text = "";
-        TextMeshProUGUI placeholderText = teamInput.placeholder as TextMeshProUGUI;
-        if (placeholderText != null)
+        /// <summary>
+        /// Sends a heartbeat value to the robot and starts waiting for response
+        /// </summary>
+        private void SendHeartbeat()
         {
-            placeholderText.text = "Current: " + team;
+            try
+            {
+                frcDataSink.PublishValue("/questnav/heartbeat/quest_to_robot", (double)heartbeatCounter);
+                lastHeartbeatSentTime = Time.time;
+                heartbeatResponsePending = true;
+                QueuedLogger.Log($"[QuestNav] Sent heartbeat #{heartbeatCounter}");
+            }
+            catch (Exception ex)
+            {
+                QueuedLogger.LogWarning($"[QuestNav] Error sending heartbeat: {ex.Message}");
+                // Don't set heartbeatResponsePending to true if we couldn't send
+            }
         }
-        else
-        {
-            QueuedLogger.LogError("Placeholder is not assigned or not a TextMeshProUGUI component.");
-        }
-    }
-    #endregion
 
-    #region Helper Methods
-    /// <summary>
-    /// Generates the IP address for the roboRIO based on team number
-    /// </summary>
-    /// <returns>The formatted IP address string</returns>
-    private string generateIP()
-    {
-        if (teamNumber.Length >= 1)
+        /// <summary>
+        /// Checks for a heartbeat response from the robot
+        /// </summary>
+        private void CheckHeartbeatResponse()
         {
-            string tePart = teamNumber.Length > 2 ? teamNumber.Substring(0, teamNumber.Length - 2) : "0";
-            string amPart = teamNumber.Length > 2 ? teamNumber.Substring(teamNumber.Length - 2) : teamNumber;
-            return serverAddress.Replace("TE", tePart).Replace("AM", amPart);
+            try
+            {
+                double response = frcDataSink.GetDouble("/questnav/heartbeat/robot_to_quest");
+                
+                if ((int)response == heartbeatCounter)
+                {
+                    // Valid response received
+                    heartbeatResponsePending = false;
+                    lastHeartbeatResponseTime = Time.time;
+                    consecutiveFailedHeartbeats = 0;
+                    QueuedLogger.Log($"[QuestNav] Received heartbeat response #{heartbeatCounter}");
+                    
+                    // Increment heartbeat counter for next round (with overflow protection)
+                    heartbeatCounter++;
+                    if (heartbeatCounter > 1000000) heartbeatCounter = 1;
+                }
+            }
+            catch (Exception ex)
+            {
+                QueuedLogger.LogWarning($"[QuestNav] Error checking heartbeat response: {ex.Message}");
+                // Don't reset heartbeatResponsePending here - let the timeout handle it
+            }
         }
-        else
-        {
-            return "10.0.0.2";
-        }
-    }
 
-    /// <summary>
-    /// Event handler for when the input field is selected
-    /// </summary>
-    /// <param name="text">The current text in the input field</param>
-    private void OnInputFieldSelected(string text)
-    {
-        QueuedLogger.Log("[QuestNav] Input Selected");
+        /// <summary>
+        /// Forces a reconnection due to heartbeat failure
+        /// Resets connection state and begins a new connection attempt
+        /// </summary>
+        private void ForceReconnection()
+        {
+            QueuedLogger.Log("[QuestNav] Forcing reconnection due to heartbeat failure");
+            
+            // Reset heartbeat state
+            heartbeatResponsePending = false;
+            consecutiveFailedHeartbeats = 0;
+            
+            // Disconnect existing connection
+            if (frcDataSink != null)
+            {
+                try
+                {
+                    frcDataSink.Client.Disconnect();
+                }
+                catch (Exception ex)
+                {
+                    QueuedLogger.LogWarning($"[QuestNav] Error disconnecting: {ex.Message}");
+                }
+                frcDataSink = null;
+            }
+            
+            // Reset connection state flags to enable reconnection
+            connectionAttempt = false;
+            connectionAttemptCompleted = true;
+            
+            // Initiate reconnection
+            ConnectToRobot();
+        }
+        #endregion
+
+        #region Network Connection Methods
+        /// <summary>
+        /// Called to start the connection process.
+        /// Manages connection flags and starts the coroutine for connection.
+        /// </summary>
+        private void ConnectToRobot()
+        {
+            // Don't start multiple connection attempts
+            if (connectionAttempt)
+            {
+                QueuedLogger.LogWarning("[QuestNav] Connection attempt already in progress, skipping new request");
+                return;
+            }
+            
+            // Set connection flags and timestamp for timeout tracking
+            connectionAttempt = true;
+            connectionAttemptCompleted = false;
+            connectionAttemptStartTime = Time.time;
+            
+            // Cancel any existing connection coroutine
+            if (_connectionCoroutine != null)
+            {
+                StopCoroutine(_connectionCoroutine);
+            }
+            
+            // Start a new connection attempt
+            _connectionCoroutine = StartCoroutine(ConnectionCoroutineWrapper());
+        }
+
+        /// <summary>
+        /// A coroutine wrapper that waits until the asynchronous connection method completes.
+        /// This wrapper enables setting timeout guardbands for the connection process.
+        /// </summary>
+        private IEnumerator ConnectionCoroutineWrapper()
+        {
+            var connectionTask = AttemptConnectionAsync();
+            
+            while (!connectionTask.IsCompleted)
+            {
+                yield return null;
+            }
+            
+            // Check if the task completed successfully
+            if (connectionTask.IsFaulted)
+            {
+                QueuedLogger.LogError($"[QuestNav] Connection attempt failed with exception: {connectionTask.Exception}");
+                connectionAttempt = false;  // Reset flag to allow new attempts
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously attempts to connect to one of the candidate addresses.
+        /// Uses async DNS resolution and wraps blocking calls in Task.Run to avoid blocking the main Unity thread.
+        /// Will try candidates until successful or all fail, then retry with exponential backoff.
+        /// </summary>
+        private async Task AttemptConnectionAsync()
+        {
+            bool connectionEstablished = false;
+            List<string> candidateAddresses = new List<string>()
+            {
+                generateIP(),
+                "172.22.11.2",
+                $"roboRIO-{teamNumber}-FRC.local",
+                $"roboRIO-{teamNumber}-FRC.lan",
+                $"roboRIO-{teamNumber}-FRC.frc-field.local"
+            };
+
+            while (!connectionEstablished)
+            {
+                // Check if the network is reachable.
+                if (Application.internetReachability == NetworkReachability.NotReachable)
+                {
+                    QueuedLogger.LogWarning($"[QuestNav] Network not reachable. Waiting {unreachableNetworkDelay} seconds before reattempting.");
+                    conStateMessage = "net no reach waiting";
+                    await Task.Delay(unreachableNetworkDelay);
+                    continue;
+                }
+
+                StringBuilder cycleLog = new StringBuilder();
+                cycleLog.AppendLine("[QuestNav] Connection attempt cycle:");
+                conStateMessage = "connection attempt cycle";
+
+                foreach (string candidate in candidateAddresses)
+                {
+                    // Skip a candidate if it failed recently.
+                    if (failedCandidates.ContainsKey(candidate) && (Time.time - failedCandidates[candidate] < candidateFailureCooldown))
+                    {
+                        cycleLog.AppendLine($"Skipping candidate {candidate} (failed less than {candidateFailureCooldown} seconds ago).");
+                        conStateMessage = "skipping " + candidate + " cool " + candidateFailureCooldown;
+                        continue;
+                    }
+                    else
+                    {
+                        failedCandidates.Remove(candidate);
+                        conStateMessage = "removed candidate " + candidate;
+                    }
+
+                    string resolvedAddress = candidate;
+                    try
+                    {
+                        // Use asynchronous DNS resolution.
+                        IPHostEntry hostEntry = await Dns.GetHostEntryAsync(candidate);
+                        IPAddress[] ipv4Addresses = hostEntry.AddressList
+                            .Where(ip => ip.AddressFamily == AddressFamily.InterNetwork)
+                            .ToArray();
+                        if (ipv4Addresses.Length > 0)
+                        {
+                            resolvedAddress = ipv4Addresses[0].ToString();
+                        }
+                        else
+                        {
+                            cycleLog.AppendLine($"DNS lookup returned no IPv4 for candidate '{candidate}'.");
+                            conStateMessage = "no ipv4 for " + candidate;
+                            failedCandidates[candidate] = Time.time;
+                            continue;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        cycleLog.AppendLine($"DNS resolution failed for candidate '{candidate}': {ex.Message}");
+                        conStateMessage = "dns failed for " + candidate;
+                        failedCandidates[candidate] = Time.time;
+                        continue;
+                    }
+
+                    cycleLog.AppendLine($"Attempting connection to {resolvedAddress}...");
+                    conStateMessage = "attempting " + resolvedAddress;
+
+                    try
+                    {
+                        // Wrap the potentially blocking connection call in Task.Run.
+                        var sink = await Task.Run(() =>
+                        {
+                            return new Nt4Source(appName, resolvedAddress, serverPort);
+                        });
+
+                        if (sink.Client.Connected())
+                        {
+                            ipAddress = resolvedAddress; // Cache the working address.
+                            frcDataSink = sink;
+                            cycleLog.AppendLine($"Connected successfully to {resolvedAddress}.");
+                            conStateMessage = "connected to " + resolvedAddress;
+                            connectionEstablished = true;
+                            connectionAttempt = false;
+                            connectionAttemptCompleted = true;
+                            break;
+                        }
+                        else
+                        {
+                            cycleLog.AppendLine($"Connection attempt to {resolvedAddress} did not succeed.");
+                            conStateMessage = "conn failed to " + resolvedAddress;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        cycleLog.AppendLine($"Connection attempt failed for {resolvedAddress}: {ex.Message}");
+                        conStateMessage = "conn failed " + resolvedAddress + " " + ex.Message;
+                    }
+                }
+
+                // Handle a failed connection
+                if (!connectionEstablished)
+                {
+                    cycleLog.AppendLine($"Could not establish a connection with any candidate addresses. Reattempting in {reconnectDelay} second(s)...");
+                    conStateMessage = "no conn to any candidates trying in " + reconnectDelay;
+                    QueuedLogger.Log(cycleLog.ToString(), QueuedLogger.LogLevel.Warning);
+                    await Task.Delay((int)(reconnectDelay * 1000));
+                    reconnectDelay = Mathf.Min(reconnectDelay * 2, maxReconnectDelay);
+                }
+            }
+
+            // Reset delay on success.
+            reconnectDelay = defaultReconnectDelay;
+            QueuedLogger.Log("[QuestNav] Connection established. Publishing topics.");
+            conStateMessage = "connected - publishing";
+            PublishTopics();
+        }
+
+        /// <summary>
+        /// Handles reconnection when connection is lost.
+        /// Centralizes disconnection and reconnection logic.
+        /// </summary>
+        private void HandleDisconnectedState()
+        {
+            // Prevent multiple reconnection attempts
+            if (connectionAttempt)
+            {
+                return;
+            }
+            
+            QueuedLogger.Log("[QuestNav] Robot disconnected. Resetting connection and attempting to reconnect...");
+            conStateMessage = "robot disconnected - retrying";
+            
+            // Safely disconnect if we have a connection
+            if (frcDataSink != null)
+            {
+                try
+                {
+                    frcDataSink.Client.Disconnect();
+                }
+                catch (Exception ex)
+                {
+                    QueuedLogger.LogWarning($"[QuestNav] Error disconnecting: {ex.Message}");
+                }
+                frcDataSink = null;
+            }
+            
+            // Start a fresh connection attempt
+            ConnectToRobot();
+        }
+
+        /// <summary>
+        /// Publishes and subscribes to required NetworkTables topics
+        /// Includes heartbeat topics for connection monitoring
+        /// </summary>
+        private void PublishTopics()
+        {
+            // Standard QuestNav topics
+            frcDataSink.PublishTopic("/questnav/miso", "int");
+            frcDataSink.PublishTopic("/questnav/frameCount", "int");
+            frcDataSink.PublishTopic("/questnav/timestamp", "double");
+            frcDataSink.PublishTopic("/questnav/position", "float[]");
+            frcDataSink.PublishTopic("/questnav/quaternion", "float[]");
+            frcDataSink.PublishTopic("/questnav/eulerAngles", "float[]");
+            frcDataSink.PublishTopic("/questnav/batteryPercent", "double");
+            frcDataSink.Subscribe("/questnav/mosi", 0.1, false, false, false);
+            frcDataSink.Subscribe("/questnav/init/position", 0.1, false, false, false);
+            frcDataSink.Subscribe("/questnav/init/eulerAngles", 0.1, false, false, false);
+            frcDataSink.Subscribe("/questnav/resetpose", 0.1, false, false, false);
+            
+            // Heartbeat system topics
+            frcDataSink.PublishTopic("/questnav/heartbeat/quest_to_robot", "double");
+            frcDataSink.Subscribe("/questnav/heartbeat/robot_to_quest", 0.1, false, false, false);
+            
+            // Reset heartbeat state when establishing a new connection
+            heartbeatCounter = 1;
+            heartbeatResponsePending = false;
+            consecutiveFailedHeartbeats = 0;
+            lastHeartbeatSentTime = Time.time;
+        }
+        #endregion
+
+        #region Data Publishing Methods
+        /// <summary>
+        /// Publishes current frame data to NetworkTables
+        /// </summary>
+        private void PublishFrameData()
+        {
+            frameIndex = Time.frameCount;
+            timeStamp = Time.time;
+            position = cameraRig.centerEyeAnchor.position;
+            rotation = cameraRig.centerEyeAnchor.rotation;
+            eulerAngles = cameraRig.centerEyeAnchor.eulerAngles;
+            batteryPercent = SystemInfo.batteryLevel * 100;
+
+            frcDataSink.PublishValue("/questnav/frameCount", frameIndex);
+            frcDataSink.PublishValue("/questnav/timestamp", timeStamp);
+            frcDataSink.PublishValue("/questnav/position", position.ToArray());
+            frcDataSink.PublishValue("/questnav/quaternion", rotation.ToArray());
+            frcDataSink.PublishValue("/questnav/eulerAngles", eulerAngles.ToArray());
+            frcDataSink.PublishValue("/questnav/batteryPercent", batteryPercent);
+        }
+        #endregion
+
+        #region Command Processing Methods
+        /// <summary>
+        /// Processes commands received from the robot
+        /// </summary>
+        private void ProcessCommands()
+        {
+            command = frcDataSink.GetLong("/questnav/mosi");
+
+            if (resetInProgress && command == 0)
+            {
+                resetInProgress = false;
+                QueuedLogger.Log("[QuestNav] Reset operation completed");
+                return;
+            }
+
+            switch (command)
+            {
+                case 1:
+                    if (!resetInProgress)
+                    {
+                        QueuedLogger.Log("[QuestNav] Received heading reset request, initiating recenter...");
+                        RecenterPlayer();
+                        resetInProgress = true;
+                    }
+                    break;
+                case 2:
+                    if (!resetInProgress)
+                    {
+                        QueuedLogger.Log("[QuestNav] Received pose reset request, initiating reset...");
+                        InitiatePoseReset();
+                        QueuedLogger.Log("[QuestNav] Processing pose reset request.");
+                        resetInProgress = true;
+                    }
+                    break;
+                case 3:
+                    QueuedLogger.Log("[QuestNav] Ping received, responding...");
+                    frcDataSink.PublishValue("/questnav/miso", 97);  // 97 for ping response
+                    break;
+                default:
+                    if (!resetInProgress)
+                    {
+                        frcDataSink.PublishValue("/questnav/miso", 0);
+                    }
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Initiates a pose reset based on received NetworkTables data
+        /// </summary>
+        private void InitiatePoseReset()
+        {
+            try {
+                // Constants for retry logic and field dimensions
+                const int maxRetries = 3;              // Maximum number of attempts to read pose data
+                const float retryDelayMs = 50f;        // Delay between retry attempts
+                const float FIELD_LENGTH = 16.54f;     // FRC field length in meters
+                const float FIELD_WIDTH = 8.02f;       // FRC field width in meters
+
+                double[] resetPose = null;
+                bool success = false;
+                int attemptCount = 0;
+
+                // Attempt to read pose data from NetworkTables with retry logic
+                for (int i = 0; i < maxRetries && !success; i++)
+                {
+                    attemptCount++;
+                    // Add delay between retries to allow for network latency
+                    if (i > 0) {
+                        System.Threading.Thread.Sleep((int)retryDelayMs);
+                        QueuedLogger.Log($"[QuestNav] Attempt {attemptCount} of {maxRetries}...");
+                    }
+
+                    QueuedLogger.Log($"[QuestNav] Reading NetworkTables Values (Attempt {attemptCount}):");
+
+                    // Read the pose array from NetworkTables
+                    // Format: [X, Y, Rotation] in FRC field coordinates
+                    resetPose = frcDataSink.GetDoubleArray("/questnav/resetpose");
+
+                    // Validate pose data format and field boundaries
+                    if (resetPose != null && resetPose.Length == 3) {
+                        // Check if pose is within valid field boundaries
+                        if (resetPose[0] < 0 || resetPose[0] > FIELD_LENGTH ||
+                            resetPose[1] < 0 || resetPose[1] > FIELD_WIDTH) {
+                            QueuedLogger.LogWarning($"[QuestNav] Reset pose outside field boundaries: X:{resetPose[0]:F3} Y:{resetPose[1]:F3}");
+                            continue;
+                        }
+                        success = true;
+                        QueuedLogger.Log($"[QuestNav] Successfully read reset pose values on attempt {attemptCount}");
+                    }
+
+                    QueuedLogger.Log($"[QuestNav] Values (Attempt {attemptCount}): X:{resetPose?[0]:F3} Y:{resetPose?[1]:F3} Rot:{resetPose?[2]:F3}");
+                }
+
+                // Exit if we couldn't get valid pose data
+                if (!success) {
+                    QueuedLogger.LogWarning($"[QuestNav] Failed to read valid reset pose values after {attemptCount} attempts");
+                    return;
+                }
+
+                // Extract pose components from the array
+                double resetX = resetPose[0];          // FRC X coordinate (along length of field)
+                double resetY = resetPose[1];          // FRC Y coordinate (along width of field)
+                double resetRotation = resetPose[2];   // FRC rotation (CCW positive)
+
+                // Normalize rotation to -180 to 180 degrees range
+                while (resetRotation > 180) resetRotation -= 360;
+                while (resetRotation < -180) resetRotation += 360;
+
+                QueuedLogger.Log($"[QuestNav] Starting pose reset - Target: FRC X:{resetX:F2} Y:{resetY:F2} Rot:{resetRotation:F2}°");
+
+                // Store current VR camera state for reference
+                Vector3 currentCameraPos = vrCamera.position;
+                Quaternion currentCameraRot = vrCamera.rotation;
+
+                QueuedLogger.Log($"[QuestNav] Before reset - Camera Pos:{currentCameraPos:F3} Rot:{currentCameraRot.eulerAngles:F3}");
+
+                // Convert FRC coordinates to Unity coordinates:
+                // Unity uses a left-handed coordinate system with Y as the vertical axis (aligned with gravity)
+                // FRC uses a right-handed coordinate system with Z as the vertical axis (aligned with gravity)
+                // See this page for more Unity details: https://docs.unity3d.com/Manual/QuaternionAndEulerRotationsInUnity.html
+                // See this page for more FRC details: https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html
+
+                // - Unity X = -FRC Y (right is positive in Unity)
+                // - Unity Y = kept unchanged (height)
+                // - Unity Z = FRC X (forward is positive in both)
+                Vector3 targetUnityPosition = new Vector3(
+                    (float)(-resetY),         // Negate Y for Unity's coordinate system
+                    currentCameraPos.y,       // Maintain current height
+                    (float)resetX            // FRC X maps directly to Unity Z
+                );
+
+                // Calculate the position difference we need to move
+                Vector3 positionDelta = targetUnityPosition - currentCameraPos;
+
+                // Convert FRC rotation to Unity rotation:
+                // - Unity uses clockwise positive rotation around Y
+                // - FRC uses counterclockwise positive rotation
+                float targetUnityYaw = (float)(-resetRotation);  // Negate for Unity's rotation direction
+                float currentYaw = currentCameraRot.eulerAngles.y;
+
+                // Normalize both angles to 0-360 range for proper delta calculation
+                while (currentYaw < 0) currentYaw += 360;
+                while (targetUnityYaw < 0) targetUnityYaw += 360;
+
+                // Calculate rotation delta and normalize to -180 to 180 range
+                float yawDelta = targetUnityYaw - currentYaw;
+                if (yawDelta > 180) yawDelta -= 360;
+                if (yawDelta < -180) yawDelta += 360;
+
+                QueuedLogger.Log($"[QuestNav] Calculated adjustments - Position delta:{positionDelta:F3} Rotation delta:{yawDelta:F3}°");
+                QueuedLogger.Log($"[QuestNav] Target Unity Position: {targetUnityPosition:F3}");
+
+                // Store the original offset between camera and its root
+                // This helps maintain proper VR tracking space
+                Vector3 cameraOffset = vrCamera.position - vrCameraRoot.position;
+
+                // First rotate the root around the camera position
+                // This maintains the camera's position while changing orientation
+                vrCameraRoot.RotateAround(vrCamera.position, Vector3.up, yawDelta);
+
+                // Then apply the position adjustment to achieve target position
+                vrCameraRoot.position += positionDelta;
+
+                // Log final position and rotation for verification
+                QueuedLogger.Log($"[QuestNav] After reset - Camera Pos:{vrCamera.position:F3} Rot:{vrCamera.rotation.eulerAngles:F3}");
+
+                // Calculate and check position error to ensure accuracy
+                float posError = Vector3.Distance(vrCamera.position, targetUnityPosition);
+                QueuedLogger.Log($"[QuestNav] Position error after reset: {posError:F3}m");
+
+                // Warn if position error is larger than expected threshold
+                if (posError > 0.01f) {  // 1cm threshold
+                    QueuedLogger.LogWarning($"[QuestNav] Large position error detected!");
+                }
+
+                frcDataSink.PublishValue("/questnav/miso", 98);
+            }
+            catch (Exception e) {
+                QueuedLogger.LogError($"[QuestNav] Error during pose reset: {e.Message}");
+                QueuedLogger.LogException(e);
+                frcDataSink.PublishValue("/questnav/miso", 0);
+                resetInProgress = false;
+            }
+        }
+
+        /// <summary>
+        /// Recenters the player's view by adjusting the VR camera root transform to match the reset transform.
+        /// Similar to the effect of long-pressing the Oculus button.
+        /// </summary>
+        void RecenterPlayer()
+        {
+            try {
+                float rotationAngleY = vrCamera.rotation.eulerAngles.y - resetTransform.rotation.eulerAngles.y;
+
+                vrCameraRoot.transform.Rotate(0, -rotationAngleY, 0);
+
+                Vector3 distanceDiff = resetTransform.position - vrCamera.position;
+                vrCameraRoot.transform.position += distanceDiff;
+
+                frcDataSink.PublishValue("/questnav/miso", 99);
+            }
+            catch (Exception e) {
+                QueuedLogger.LogError($"[QuestNav] Error during pose reset: {e.Message}");
+                QueuedLogger.LogException(e);
+                frcDataSink.PublishValue("/questnav/miso", 0);
+                resetInProgress = false;
+            }
+        }
+        #endregion
+
+        #region UI Methods
+        /// <summary>
+        /// Updates the team number based on user input and triggers an asynchronous connection reset.
+        /// </summary>
+        public void UpdateTeamNumber()
+        {
+            QueuedLogger.Log("[QuestNav] Updating Team Number");
+            teamNumber = teamInput.text;
+            PlayerPrefs.SetString("TeamNumber", teamNumber);
+            PlayerPrefs.Save();
+            setInputBox(teamNumber);
+
+            // Clear cached IP and candidate failure data.
+            ipAddress = "";
+            failedCandidates.Clear();
+
+            // If a connection coroutine is already running, stop it.
+            if (_connectionCoroutine != null)
+            {
+                StopCoroutine(_connectionCoroutine);
+                _connectionCoroutine = null;
+            }
+
+            // Disconnect existing connection, if any.
+            if (frcDataSink != null)
+            {
+                if (frcDataSink.Client.Connected())
+                {
+                    frcDataSink.Client.Disconnect();
+                }
+                frcDataSink = null;
+            }
+
+            // Reset connection state and restart connection process
+            connectionAttempt = false;
+            connectionAttemptCompleted = true;
+            
+            // Restart the asynchronous connection process.
+            ConnectToRobot();
+        }
+
+        /// <summary>
+        /// Updates the default IP address shown in the UI with the current HMD IP address
+        /// </summary>
+        /// 
+        public void UpdateIPAddressText()
+        {
+            //Get the local IP
+            IPHostEntry hostEntry = Dns.GetHostEntry(Dns.GetHostName());
+            foreach (IPAddress ip in hostEntry.AddressList)
+            {
+                if (ip.AddressFamily == AddressFamily.InterNetwork)
+                {
+                    myAddressLocal = ip.ToString();
+                    TextMeshProUGUI ipText = ipAddressText as TextMeshProUGUI;
+                    if (myAddressLocal == "127.0.0.1")
+                    {
+                        ipText.text = "No Adapter Found";
+                    }
+                    else
+                    {
+                        ipText.text = myAddressLocal;
+                    }
+                }
+                break;
+            }
+        }
+
+        public void UpdateConStateText()
+        {
+            TextMeshProUGUI conText = conStateText as TextMeshProUGUI;
+            conText.text = conStateMessage;
+        }
+
+        /// <summary>
+        /// Updates the input box placeholder text with the current team number
+        /// </summary>
+        /// <param name="team">The team number to display</param>
+        private void setInputBox(string team)
+        {
+            teamInput.text = "";
+            TextMeshProUGUI placeholderText = teamInput.placeholder as TextMeshProUGUI;
+            if (placeholderText != null)
+            {
+                placeholderText.text = "Current: " + team;
+            }
+            else
+            {
+                QueuedLogger.LogError("Placeholder is not assigned or not a TextMeshProUGUI component.");
+            }
+        }
+        #endregion
+
+        #region Helper Methods
+        /// <summary>
+        /// Generates the IP address for the roboRIO based on team number
+        /// </summary>
+        /// <returns>The formatted IP address string</returns>
+        private string generateIP()
+        {
+            if (teamNumber.Length >= 1)
+            {
+                string tePart = teamNumber.Length > 2 ? teamNumber.Substring(0, teamNumber.Length - 2) : "0";
+                string amPart = teamNumber.Length > 2 ? teamNumber.Substring(teamNumber.Length - 2) : teamNumber;
+                return serverAddress.Replace("TE", tePart).Replace("AM", amPart);
+            }
+            else
+            {
+                return "10.0.0.2";
+            }
+        }
+
+        /// <summary>
+        /// Event handler for when the input field is selected
+        /// </summary>
+        /// <param name="text">The current text in the input field</param>
+        private void OnInputFieldSelected(string text)
+        {
+            QueuedLogger.Log("[QuestNav] Input Selected");
+        }
+        #endregion
     }
-    #endregion
 }

--- a/unity/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
+++ b/unity/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
@@ -33,24 +33,24 @@ MonoBehaviour:
   m_Settings:
     m_SettingsList:
       m_List:
-      - rid: 2852379616146358550
-      - rid: 2852379616146358551
+      - rid: 7165685798308413514
+      - rid: 7165685798308413515
       - rid: 6852985685364965378
       - rid: 6852985685364965379
       - rid: 6852985685364965380
       - rid: 6852985685364965381
-      - rid: 2852379616146358552
-      - rid: 2852379616146358553
+      - rid: 7165685798308413516
+      - rid: 7165685798308413517
       - rid: 6852985685364965384
       - rid: 6852985685364965385
-      - rid: 2852379616146358554
-      - rid: 2852379616146358555
-      - rid: 2852379616146358556
-      - rid: 2852379616146358557
-      - rid: 2852379616146358558
-      - rid: 2852379616146358559
+      - rid: 7165685798308413518
+      - rid: 7165685798308413519
+      - rid: 7165685798308413520
+      - rid: 7165685798308413521
+      - rid: 7165685798308413522
+      - rid: 7165685798308413523
       - rid: 6852985685364965392
-      - rid: 2852379616146358560
+      - rid: 7165685798308413524
       - rid: 6852985685364965394
       - rid: 8712630790384254976
       - rid: 7815359781915852800
@@ -96,109 +96,6 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 2852379616146358550
-      type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
-      data:
-        m_Version: 0
-        m_StripUnusedPostProcessingVariants: 1
-        m_StripUnusedVariants: 1
-        m_StripScreenCoordOverrideVariants: 1
-    - rid: 2852379616146358551
-      type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
-      data:
-        m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
-        m_AutodeskInteractiveTransparent: {fileID: 4800000, guid: 5c81372d981403744adbdda4433c9c11, type: 3}
-        m_AutodeskInteractiveMasked: {fileID: 4800000, guid: 80aa867ac363ac043847b06ad71604cd, type: 3}
-        m_TerrainDetailLit: {fileID: 4800000, guid: f6783ab646d374f94b199774402a5144, type: 3}
-        m_TerrainDetailGrassBillboard: {fileID: 4800000, guid: 29868e73b638e48ca99a19ea58c48d90, type: 3}
-        m_TerrainDetailGrass: {fileID: 4800000, guid: e507fdfead5ca47e8b9a768b51c291a1, type: 3}
-        m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
-        m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
-        m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
-    - rid: 2852379616146358552
-      type: {class: Renderer2DResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
-      data:
-        m_Version: 0
-        m_LightShader: {fileID: 4800000, guid: 3f6c848ca3d7bca4bbe846546ac701a1, type: 3}
-        m_ProjectedShadowShader: {fileID: 4800000, guid: ce09d4a80b88c5a4eb9768fab4f1ee00, type: 3}
-        m_SpriteShadowShader: {fileID: 4800000, guid: 44fc62292b65ab04eabcf310e799ccf6, type: 3}
-        m_SpriteUnshadowShader: {fileID: 4800000, guid: de02b375720b5c445afe83cd483bedf3, type: 3}
-        m_GeometryShadowShader: {fileID: 4800000, guid: 19349a0f9a7ed4c48a27445bcf92e5e1, type: 3}
-        m_GeometryUnshadowShader: {fileID: 4800000, guid: 77774d9009bb81447b048c907d4c6273, type: 3}
-        m_FallOffLookup: {fileID: 2800000, guid: 5688ab254e4c0634f8d6c8e0792331ca, type: 3}
-        m_CopyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
-        m_DefaultLitMaterial: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-        m_DefaultUnlitMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
-        m_DefaultMaskMaterial: {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
-    - rid: 2852379616146358553
-      type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
-      data:
-        m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
-        m_DefaultParticleMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
-        m_DefaultLineMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
-        m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
-        m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
-    - rid: 2852379616146358554
-      type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
-      data:
-        m_Version: 0
-        m_InstanceDataBufferCopyKernels: {fileID: 7200000, guid: f984aeb540ded8b4fbb8a2047ab5b2e2, type: 3}
-        m_InstanceDataBufferUploadKernels: {fileID: 7200000, guid: 53864816eb00f2343b60e1a2c5a262ef, type: 3}
-        m_TransformUpdaterKernels: {fileID: 7200000, guid: 2a567b9b2733f8d47a700c3c85bed75b, type: 3}
-        m_WindDataUpdaterKernels: {fileID: 7200000, guid: fde76746e4fd0ed418c224f6b4084114, type: 3}
-        m_OccluderDepthPyramidKernels: {fileID: 7200000, guid: 08b2b5fb307b0d249860612774a987da, type: 3}
-        m_InstanceOcclusionCullingKernels: {fileID: 7200000, guid: f6d223acabc2f974795a5a7864b50e6c, type: 3}
-        m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
-        m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
-        m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
-    - rid: 2852379616146358555
-      type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
-        m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
-        m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
-    - rid: 2852379616146358556
-      type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_Version: 1
-        dilationShader: {fileID: 7200000, guid: 6bb382f7de370af41b775f54182e491d, type: 3}
-        subdivideSceneCS: {fileID: 7200000, guid: bb86f1f0af829fd45b2ebddda1245c22, type: 3}
-        voxelizeSceneShader: {fileID: 4800000, guid: c8b6a681c7b4e2e4785ffab093907f9e, type: 3}
-        traceVirtualOffsetCS: {fileID: -6772857160820960102, guid: ff2cbab5da58bf04d82c5f34037ed123, type: 3}
-        traceVirtualOffsetRT: {fileID: -5126288278712620388, guid: ff2cbab5da58bf04d82c5f34037ed123, type: 3}
-        skyOcclusionCS: {fileID: -6772857160820960102, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
-        skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
-        renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-        renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-    - rid: 2852379616146358557
-      type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_Version: 1
-        m_ProbeVolumeDisableStreamingAssets: 0
-    - rid: 2852379616146358558
-      type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_Version: 1
-        probeVolumeDebugShader: {fileID: 4800000, guid: 3b21275fd12d65f49babb5286f040f2d, type: 3}
-        probeVolumeFragmentationDebugShader: {fileID: 4800000, guid: 3a80877c579b9144ebdcc6d923bca303, type: 3}
-        probeVolumeSamplingDebugShader: {fileID: 4800000, guid: bf54e6528c79a224e96346799064c393, type: 3}
-        probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
-        probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
-        numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
-    - rid: 2852379616146358559
-      type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_version: 0
-        m_IncludeReferencedInScenes: 0
-        m_IncludeAssetsByLabel: 0
-        m_LabelToInclude: 
-    - rid: 2852379616146358560
-      type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_Version: 1
-        probeVolumeBlendStatesCS: {fileID: 7200000, guid: a3f7b8c99de28a94684cb1daebeccf5d, type: 3}
-        probeVolumeUploadDataCS: {fileID: 7200000, guid: 0951de5992461754fa73650732c4954c, type: 3}
-        probeVolumeUploadDataL2CS: {fileID: 7200000, guid: 6196f34ed825db14b81fb3eb0ea8d931, type: 3}
     - rid: 6852985685364965378
       type: {class: UniversalRendererResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
@@ -252,6 +149,109 @@ MonoBehaviour:
         m_version: 0
         m_EnableCompilationCaching: 1
         m_EnableValidityChecks: 1
+    - rid: 7165685798308413514
+      type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
+      data:
+        m_Version: 0
+        m_StripUnusedPostProcessingVariants: 1
+        m_StripUnusedVariants: 1
+        m_StripScreenCoordOverrideVariants: 1
+    - rid: 7165685798308413515
+      type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
+      data:
+        m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
+        m_AutodeskInteractiveTransparent: {fileID: 4800000, guid: 5c81372d981403744adbdda4433c9c11, type: 3}
+        m_AutodeskInteractiveMasked: {fileID: 4800000, guid: 80aa867ac363ac043847b06ad71604cd, type: 3}
+        m_TerrainDetailLit: {fileID: 4800000, guid: f6783ab646d374f94b199774402a5144, type: 3}
+        m_TerrainDetailGrassBillboard: {fileID: 4800000, guid: 29868e73b638e48ca99a19ea58c48d90, type: 3}
+        m_TerrainDetailGrass: {fileID: 4800000, guid: e507fdfead5ca47e8b9a768b51c291a1, type: 3}
+        m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
+        m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
+        m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
+    - rid: 7165685798308413516
+      type: {class: Renderer2DResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
+      data:
+        m_Version: 0
+        m_LightShader: {fileID: 4800000, guid: 3f6c848ca3d7bca4bbe846546ac701a1, type: 3}
+        m_ProjectedShadowShader: {fileID: 4800000, guid: ce09d4a80b88c5a4eb9768fab4f1ee00, type: 3}
+        m_SpriteShadowShader: {fileID: 4800000, guid: 44fc62292b65ab04eabcf310e799ccf6, type: 3}
+        m_SpriteUnshadowShader: {fileID: 4800000, guid: de02b375720b5c445afe83cd483bedf3, type: 3}
+        m_GeometryShadowShader: {fileID: 4800000, guid: 19349a0f9a7ed4c48a27445bcf92e5e1, type: 3}
+        m_GeometryUnshadowShader: {fileID: 4800000, guid: 77774d9009bb81447b048c907d4c6273, type: 3}
+        m_FallOffLookup: {fileID: 2800000, guid: 5688ab254e4c0634f8d6c8e0792331ca, type: 3}
+        m_CopyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
+        m_DefaultLitMaterial: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+        m_DefaultUnlitMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
+        m_DefaultMaskMaterial: {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
+    - rid: 7165685798308413517
+      type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
+      data:
+        m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+        m_DefaultParticleMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
+        m_DefaultLineMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
+        m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
+        m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
+    - rid: 7165685798308413518
+      type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
+      data:
+        m_Version: 0
+        m_InstanceDataBufferCopyKernels: {fileID: 7200000, guid: f984aeb540ded8b4fbb8a2047ab5b2e2, type: 3}
+        m_InstanceDataBufferUploadKernels: {fileID: 7200000, guid: 53864816eb00f2343b60e1a2c5a262ef, type: 3}
+        m_TransformUpdaterKernels: {fileID: 7200000, guid: 2a567b9b2733f8d47a700c3c85bed75b, type: 3}
+        m_WindDataUpdaterKernels: {fileID: 7200000, guid: fde76746e4fd0ed418c224f6b4084114, type: 3}
+        m_OccluderDepthPyramidKernels: {fileID: 7200000, guid: 08b2b5fb307b0d249860612774a987da, type: 3}
+        m_InstanceOcclusionCullingKernels: {fileID: 7200000, guid: f6d223acabc2f974795a5a7864b50e6c, type: 3}
+        m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
+        m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
+        m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
+    - rid: 7165685798308413519
+      type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
+        m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
+        m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
+    - rid: 7165685798308413520
+      type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_Version: 1
+        dilationShader: {fileID: 7200000, guid: 6bb382f7de370af41b775f54182e491d, type: 3}
+        subdivideSceneCS: {fileID: 7200000, guid: bb86f1f0af829fd45b2ebddda1245c22, type: 3}
+        voxelizeSceneShader: {fileID: 4800000, guid: c8b6a681c7b4e2e4785ffab093907f9e, type: 3}
+        traceVirtualOffsetCS: {fileID: -6772857160820960102, guid: ff2cbab5da58bf04d82c5f34037ed123, type: 3}
+        traceVirtualOffsetRT: {fileID: -5126288278712620388, guid: ff2cbab5da58bf04d82c5f34037ed123, type: 3}
+        skyOcclusionCS: {fileID: -6772857160820960102, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
+        skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
+        renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
+        renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
+    - rid: 7165685798308413521
+      type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_Version: 1
+        m_ProbeVolumeDisableStreamingAssets: 0
+    - rid: 7165685798308413522
+      type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_Version: 1
+        probeVolumeDebugShader: {fileID: 4800000, guid: 3b21275fd12d65f49babb5286f040f2d, type: 3}
+        probeVolumeFragmentationDebugShader: {fileID: 4800000, guid: 3a80877c579b9144ebdcc6d923bca303, type: 3}
+        probeVolumeSamplingDebugShader: {fileID: 4800000, guid: bf54e6528c79a224e96346799064c393, type: 3}
+        probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
+        probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
+        numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
+    - rid: 7165685798308413523
+      type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_version: 0
+        m_IncludeReferencedInScenes: 0
+        m_IncludeAssetsByLabel: 0
+        m_LabelToInclude: 
+    - rid: 7165685798308413524
+      type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_Version: 1
+        probeVolumeBlendStatesCS: {fileID: 7200000, guid: a3f7b8c99de28a94684cb1daebeccf5d, type: 3}
+        probeVolumeUploadDataCS: {fileID: 7200000, guid: 0951de5992461754fa73650732c4954c, type: 3}
+        probeVolumeUploadDataL2CS: {fileID: 7200000, guid: 6196f34ed825db14b81fb3eb0ea8d931, type: 3}
     - rid: 7815359781915852800
       type: {class: UniversalRenderPipelineRuntimeXRResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:


### PR DESCRIPTION
# Fix Quest-Robot Reconnection Problems

I'm back again! Thanks for making this @juchong. Figured I was overdue for a contribution.

## Problem Solved
This PR addresses the issue where QuestNav fails to reconnect when the roboRIO reboots. The connection would appear active but no data would transfer ("zombie connection").

## Key Improvements

<details>
<summary><b>🔄 Heartbeat System</b></summary>

Added bidirectional heartbeat mechanism to detect stale connections:
- Quest sends counter values to robot, which echoes them back
- After 3 consecutive failed heartbeats, forces reconnection
- Implemented in `ManageHeartbeat()`, `SendHeartbeat()`, and `CheckHeartbeatResponse()`
</details>

<details>
<summary><b>⏱️ Connection Timeout Protection</b></summary>

Added timeout monitoring for connection attempts:
- Tracks when connection attempts start with `connectionAttemptStartTime`
- Automatically resets stuck attempts after 10 seconds (configurable)
- Prevents the system from getting trapped in a "connecting" state
</details>

<details>
<summary><b>🔄 Improved State Management</b></summary>

Restructured connection handling:
- Added centralized `ForceReconnection()` method
- Improved connection state flags management
- Enhanced error handling throughout network operations
- Prevents multiple overlapping connection attempts
</details>

<details>
<summary><b>🔍 Cleaner LateUpdate Flow</b></summary>

Improved main loop logic:
1. Check for timed-out connection attempts
2. Manage connections based on state
3. Run heartbeat system before normal operations

Creates a reliable state machine that can recover from any failure condition.
</details>

## Robot-Side Requirements

On the roboRIO, add this code to echo heartbeat values:
```java
/** Subscriber for heartbeat requests */
private final DoubleSubscriber heartbeatRequestSub;
/** Publisher for heartbeat responses */
private final DoublePublisher heartbeatResponsePub;
/** Last processed heartbeat request ID */
private double lastProcessedHeartbeatId = 0;

// Initialize in constructor or setup
heartbeatRequestSub = nt4Table.getDoubleTopic("heartbeat/quest_to_robot").subscribe(0.0);
heartbeatResponsePub = nt4Table.getDoubleTopic("heartbeat/robot_to_quest").publish();

/** Process heartbeat requests from Quest and respond with the same ID */
private void processHeartbeat() {
  double requestId = heartbeatRequestSub.get();
  // Only respond to new requests to avoid flooding
  if (requestId > 0 && requestId != lastProcessedHeartbeatId) {
    heartbeatResponsePub.set(requestId);
    lastProcessedHeartbeatId = requestId;
  }
}
```
Call `processHeartbeat()` regularly in robotPeriodic or a periodic task.

## Testing

Verified reconnection works properly in sim, but haven't tested with a real robot yet. Pushing this now as Week 3 is about to start. Will be testing on our robot tomorrow. 

Let me know if any changes need to be made!

This makes QuestNav significantly more resilient to connection disruptions without requiring user intervention. The Quest handles its own connection state instead of relying on the NT4 master to notify of disconnections or trusting that NT4 will always cleanly handle it.