### PR TITLE
Timestamp Synchronization with RoboRio

### DIFF
--- a/unity/Assets/Robot/NetworkTables-CSharp/Nt4Client.cs
+++ b/unity/Assets/Robot/NetworkTables-CSharp/Nt4Client.cs
@@ -365,7 +365,7 @@ void WsSendBinary(byte[] data)
             return timestamp * 1000;
         }
         
-        private long? GetServerTimeUs() {
+        public long? GetServerTimeUs() {
             if (_serverTimeOffsetUs == null) return null;
             return GetClientTimeUs() + _serverTimeOffsetUs;
         }

--- a/unity/Assets/Robot/QuestNav.cs
+++ b/unity/Assets/Robot/QuestNav.cs
@@ -508,6 +508,18 @@ public class QuestNav : MonoBehaviour
     }
     #endregion
 
+    private double getSyncedTimestamp()
+    {
+        long? timestamp = frcDataSink.Client.GetServerTimeUs();
+        if (timestamp == null)
+        {
+            return 0.0;
+        } else
+        {
+            return timestamp.Value / 1e6; // Convert from nanoseconds to seconds timestamp
+        }
+    }
+
     #region Data Publishing Methods
     /// <summary>
     /// Publishes current frame data to NetworkTables
@@ -522,7 +534,7 @@ public class QuestNav : MonoBehaviour
         batteryPercent = SystemInfo.batteryLevel * 100;
 
         frcDataSink.PublishValue("/questnav/frameCount", frameIndex);
-        frcDataSink.PublishValue("/questnav/timestamp", timeStamp);
+        frcDataSink.PublishValue("/questnav/timestamp", getSyncedTimestamp());
         frcDataSink.PublishValue("/questnav/position", position.ToArray());
         frcDataSink.PublishValue("/questnav/quaternion", rotation.ToArray());
         frcDataSink.PublishValue("/questnav/eulerAngles", eulerAngles.ToArray());


### PR DESCRIPTION
Adds NetworkTables timestamp synchronization in order to ensure quest timestamp is in sync with RoboRio FPGA time, improving smoothness and accuracy of pose fusion with wheel odometry and other sources.