### PR TITLE
Latency Compensation for Position Resets

### DIFF
--- a/questnav-lib/src/main/java/gg/questnav/questnav/QuestNav.java
+++ b/questnav-lib/src/main/java/gg/questnav/questnav/QuestNav.java
@@ -161,7 +161,7 @@ public class QuestNav {
 
   /** Publisher for command requests */
   private final ProtobufPublisher<Commands.ProtobufQuestNavCommand> requestPublisher =
-      questNavTable.getProtobufTopic("request", commandProto).publish(PubSubOption.periodic(0.02));
+      questNavTable.getProtobufTopic("request", commandProto).publish();
 
   /** Cached request to lessen GC pressure */
   private final Commands.ProtobufQuestNavCommand cachedCommandRequest =

--- a/questnav-lib/src/main/java/gg/questnav/questnav/QuestNav.java
+++ b/questnav-lib/src/main/java/gg/questnav/questnav/QuestNav.java
@@ -161,7 +161,7 @@ public class QuestNav {
 
   /** Publisher for command requests */
   private final ProtobufPublisher<Commands.ProtobufQuestNavCommand> requestPublisher =
-      questNavTable.getProtobufTopic("request", commandProto).publish(PubSubOption.periodic(0.005));
+      questNavTable.getProtobufTopic("request", commandProto).publish(PubSubOption.periodic(0.02));
 
   /** Cached request to lessen GC pressure */
   private final Commands.ProtobufQuestNavCommand cachedCommandRequest =
@@ -248,6 +248,7 @@ public class QuestNav {
             .setPoseResetPayload(cachedPoseResetPayload.clear().setTargetPose(cachedProtoPose));
 
     requestPublisher.set(requestToSend);
+    nt4Instance.flush();
   }
 
   /**

--- a/questnav-lib/src/main/java/gg/questnav/questnav/QuestNav.java
+++ b/questnav-lib/src/main/java/gg/questnav/questnav/QuestNav.java
@@ -139,7 +139,7 @@ public class QuestNav {
           .getProtobufTopic("response", commandResponseProto)
           .subscribe(
               Commands.ProtobufQuestNavCommandResponse.newInstance(),
-              PubSubOption.periodic(0.05),
+              PubSubOption.periodic(0.005),
               PubSubOption.sendAll(true),
               PubSubOption.pollStorage(20));
 
@@ -149,7 +149,7 @@ public class QuestNav {
           .getProtobufTopic("frameData", frameDataProto)
           .subscribe(
               Data.ProtobufQuestNavFrameData.newInstance(),
-              PubSubOption.periodic(0.01),
+              PubSubOption.periodic(0.005),
               PubSubOption.sendAll(true),
               PubSubOption.pollStorage(20));
 
@@ -157,11 +157,11 @@ public class QuestNav {
   private final ProtobufSubscriber<Data.ProtobufQuestNavDeviceData> deviceDataSubscriber =
       questNavTable
           .getProtobufTopic("deviceData", deviceDataProto)
-          .subscribe(Data.ProtobufQuestNavDeviceData.newInstance());
+          .subscribe(Data.ProtobufQuestNavDeviceData.newInstance(), PubSubOption.periodic(0.02));
 
   /** Publisher for command requests */
   private final ProtobufPublisher<Commands.ProtobufQuestNavCommand> requestPublisher =
-      questNavTable.getProtobufTopic("request", commandProto).publish();
+      questNavTable.getProtobufTopic("request", commandProto).publish(PubSubOption.periodic(0.005));
 
   /** Cached request to lessen GC pressure */
   private final Commands.ProtobufQuestNavCommand cachedCommandRequest =

--- a/unity/Assets/QuestNav/Commands/CommandProcessor.cs
+++ b/unity/Assets/QuestNav/Commands/CommandProcessor.cs
@@ -14,6 +14,11 @@ namespace QuestNav.Commands
     public interface ICommandProcessor
     {
         /// <summary>
+        /// Command handler for pose reset operations
+        /// </summary>
+        public PoseResetCommand PoseResetCommand { get; }
+        
+        /// <summary>
         /// Processes commands received from the robot.
         /// </summary>
         void ProcessCommands();
@@ -32,7 +37,7 @@ namespace QuestNav.Commands
         /// <summary>
         /// Command handler for pose reset operations
         /// </summary>
-        private PoseResetCommand poseResetCommand;
+        public PoseResetCommand PoseResetCommand { get; private set; }
 
         /// <summary>
         /// Initializes a new command processor with required dependencies
@@ -55,7 +60,7 @@ namespace QuestNav.Commands
             var commandContext = new NetworkTablesCommandContext(networkTableConnection);
 
             // Initialize commands with NetworkTables context
-            poseResetCommand = new PoseResetCommand(
+            PoseResetCommand = new PoseResetCommand(
                 commandContext,
                 vrCamera,
                 vrCameraRoot,
@@ -111,7 +116,7 @@ namespace QuestNav.Commands
                                     $"Executing Pose Reset Command. ID: {receivedCommand.CommandId} "
                                         + $"Age: {ageMs} ms"
                                 );
-                                poseResetCommand.Execute(receivedCommand);
+                                PoseResetCommand.Execute(receivedCommand);
                             }
                             else
                             {

--- a/unity/Assets/QuestNav/Commands/Commands/PoseResetCommand.cs
+++ b/unity/Assets/QuestNav/Commands/Commands/PoseResetCommand.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using QuestNav.Core;
+using QuestNav.Native.NTCore;
 using QuestNav.Protos.Generated;
 using QuestNav.Utils;
 using UnityEngine;
@@ -15,6 +18,8 @@ namespace QuestNav.Commands.Commands
         private readonly Transform vrCamera;
         private readonly Transform vrCameraRoot;
         private readonly Transform resetTransform;
+
+        private Queue<KeyValuePair<double, ProtobufPose3d>> poseHistoryQueue;
 
         /// <summary>
         /// Initializes a new instance of the PoseResetCommand
@@ -34,6 +39,7 @@ namespace QuestNav.Commands.Commands
             this.vrCamera = vrCamera;
             this.vrCameraRoot = vrCameraRoot;
             this.resetTransform = resetTransform;
+            poseHistoryQueue = new Queue<KeyValuePair<double, ProtobufPose3d>>(QuestNavConstants.Commands.MAX_POSE_HISTORY);
         }
 
         /// <summary>
@@ -131,7 +137,7 @@ namespace QuestNav.Commands.Commands
 
                 QueuedLogger.Log(
                     $"Pose reset applied: X={poseX}, Y={poseY}, Z={poseZ} Rotation X={targetCameraRotation.eulerAngles.x}, "
-                        + $"Y={targetCameraRotation.eulerAngles.y}, Z={targetCameraRotation.eulerAngles.z}"
+                    + $"Y={targetCameraRotation.eulerAngles.y}, Z={targetCameraRotation.eulerAngles.z}"
                 );
 
                 // Send success response via command context

--- a/unity/Assets/QuestNav/Core/QuestNav.cs
+++ b/unity/Assets/QuestNav/Core/QuestNav.cs
@@ -324,10 +324,10 @@ namespace QuestNav.Core
                 rotation,
                 currentlyTracking
             );
-
-            // Immediately flush new data to NT
-            networkTableConnection.MainPeriodic();
-
+            
+            // Update position reset FIFO Queue
+            commandProcessor.PoseResetCommand.UpdatePoseHistory(networkTableConnection.NtNow);
+            
             // Check for and execute any pending commands from the robot
             // Commands include pose resets, calibration requests, etc.
             commandProcessor.ProcessCommands();

--- a/unity/Assets/QuestNav/Core/QuestNav.cs
+++ b/unity/Assets/QuestNav/Core/QuestNav.cs
@@ -324,7 +324,7 @@ namespace QuestNav.Core
                 rotation,
                 currentlyTracking
             );
-            
+
             // Immediately flush new data to NT
             networkTableConnection.MainPeriodic();
 

--- a/unity/Assets/QuestNav/Core/QuestNav.cs
+++ b/unity/Assets/QuestNav/Core/QuestNav.cs
@@ -324,6 +324,9 @@ namespace QuestNav.Core
                 rotation,
                 currentlyTracking
             );
+            
+            // Immediately flush new data to NT
+            networkTableConnection.MainPeriodic();
 
             // Check for and execute any pending commands from the robot
             // Commands include pose resets, calibration requests, etc.
@@ -347,7 +350,7 @@ namespace QuestNav.Core
         private void SlowUpdate()
         {
             // Poll for connection status, logging, ip address changes, etc.
-            networkTableConnection.Periodic();
+            networkTableConnection.SlowPeriodic();
 
             // Update UI elements like connection status, IP address display, team number validation
             // UI updates don't need to be real-time, 3Hz provides smooth visual feedback

--- a/unity/Assets/QuestNav/Core/QuestNavConstants.cs
+++ b/unity/Assets/QuestNav/Core/QuestNavConstants.cs
@@ -93,7 +93,12 @@ namespace QuestNav.Core
             /// <summary>
             /// Time to live for pose reset command (ms). Commands older than this will be ignored.
             /// </summary>
-            public const int POSE_RESET_TTL_MS = 50;
+            public const int POSE_RESET_TTL_MS = 75;
+            
+            /// <summary>
+            /// The max history to store for latency compensation pose queue. Shouldn't be larger than POSE_RESET_TTL_MS / 6.33ms 
+            /// </summary>
+            public const int MAX_POSE_HISTORY = 10;
         }
 
         /// <summary>

--- a/unity/Assets/QuestNav/Native/NTCore/NtCoreNatives.cs
+++ b/unity/Assets/QuestNav/Native/NTCore/NtCoreNatives.cs
@@ -409,7 +409,7 @@ namespace QuestNav.Native.NTCore
 
         [DllImport("ntcore")]
         public static extern long NT_Now();
-        
+
         [DllImport("ntcore")]
         public static extern void NT_Flush(uint inst);
     }

--- a/unity/Assets/QuestNav/Native/NTCore/NtCoreNatives.cs
+++ b/unity/Assets/QuestNav/Native/NTCore/NtCoreNatives.cs
@@ -409,5 +409,8 @@ namespace QuestNav.Native.NTCore
 
         [DllImport("ntcore")]
         public static extern long NT_Now();
+        
+        [DllImport("ntcore")]
+        public static extern void NT_Flush(uint inst);
     }
 }

--- a/unity/Assets/QuestNav/Native/NTCore/NtInstance.cs
+++ b/unity/Assets/QuestNav/Native/NTCore/NtInstance.cs
@@ -316,6 +316,20 @@ namespace QuestNav.Native.NTCore
         }
 
         /// <summary>
+        /// Forces an immediate flush of all local entry changes to network.
+        /// Normally this is done on a regularly scheduled interval (set
+        /// by update rates on individual publishers).
+        ///
+        /// Note: flushes are rate limited to avoid excessive network traffic.  If
+        /// the time between calls is too short, the flush will occur after the minimum
+        /// time elapses---5ms---rather than immediately.
+        /// </summary>
+        public void Flush()
+        {
+            NtCoreNatives.NT_Flush(handle);
+        }
+
+        /// <summary>
         /// Maps an NtType to its NetworkTables type string representation (e.g., "boolean", "string[]").
         /// </summary>
         /// <param name="type">The NetworkTables type.</param>

--- a/unity/Assets/QuestNav/Native/NTCore/PubSubOptions.cs
+++ b/unity/Assets/QuestNav/Native/NTCore/PubSubOptions.cs
@@ -14,7 +14,7 @@ namespace QuestNav.Native.NTCore
         public static PubSubOptions AllDefault { get; } =
             new PubSubOptions()
             {
-                Periodic = 0.005,
+                Periodic = 0.02,
                 SendAll = true,
                 KeepDuplicates = true,
                 PollStorage = 0,

--- a/unity/Assets/QuestNav/Network/NetworkTableConnection.cs
+++ b/unity/Assets/QuestNav/Network/NetworkTableConnection.cs
@@ -52,11 +52,6 @@ namespace QuestNav.Network
         string IpAddress { get; }
 
         /// <summary>
-        /// Main periodic loop to run at the max rate. Flushes all queued updates immediately for maximum performance.
-        /// </summary>
-        void MainPeriodic();
-
-        /// <summary>
         /// Publishes frame data to NetworkTables.
         /// </summary>
         /// <param name="frameCount">Current frame index</param>
@@ -388,6 +383,7 @@ namespace QuestNav.Network
 
             // Publish data
             frameDataPublisher.Set(frameData);
+            ntInstance.Flush();
         }
 
         /// <summary>
@@ -407,6 +403,7 @@ namespace QuestNav.Network
 
             // Publish data
             deviceDataPublisher.Set(deviceData);
+            // Don't flush here, it will be flushed anyways next frame when we call PublishFrameData
         }
 
         /// <summary>
@@ -495,14 +492,6 @@ namespace QuestNav.Network
             {
                 OnDisconnect?.Invoke();
             }
-        }
-
-        /// <summary>
-        /// Main periodic loop to run at the max rate. Flushes all queued updates immediately for maximum performance.
-        /// </summary>
-        public void MainPeriodic()
-        {
-            ntInstance.Flush();
         }
 
         /// <summary>

--- a/unity/Assets/QuestNav/Network/NetworkTableConnection.cs
+++ b/unity/Assets/QuestNav/Network/NetworkTableConnection.cs
@@ -50,12 +50,12 @@ namespace QuestNav.Network
         /// Caches the last known IP address to detect changes
         /// </summary>
         string IpAddress { get; }
-        
+
         /// <summary>
         /// Main periodic loop to run at the max rate. Flushes all queued updates immediately for maximum performance.
         /// </summary>
         void MainPeriodic();
-        
+
         /// <summary>
         /// Publishes frame data to NetworkTables.
         /// </summary>
@@ -249,7 +249,7 @@ namespace QuestNav.Network
                 {
                     SendAll = true,
                     KeepDuplicates = true,
-                    Periodic = 0.005,
+                    Periodic = 0.02,
                     PollStorage = 20,
                 }
             );
@@ -313,7 +313,7 @@ namespace QuestNav.Network
 
             // Standard mode: Use team number to resolve robot address
             QueuedLogger.Log($"Setting Team number to {teamNumber}");
-            ntInstance.SetAddresses(new (string addr, int port)[]{});
+            ntInstance.SetAddresses(new (string addr, int port)[] { });
             ntInstance.SetTeamNumber(teamNumber, QuestNavConstants.Network.NT_SERVER_PORT);
             teamNumberSet = true;
             ipAddressSet = false;
@@ -504,6 +504,7 @@ namespace QuestNav.Network
         {
             ntInstance.Flush();
         }
+
         /// <summary>
         /// Performs periodic updates including connection polling and logging.
         /// </summary>

--- a/unity/Assets/QuestNav/Network/NetworkTableConnection.cs
+++ b/unity/Assets/QuestNav/Network/NetworkTableConnection.cs
@@ -50,7 +50,12 @@ namespace QuestNav.Network
         /// Caches the last known IP address to detect changes
         /// </summary>
         string IpAddress { get; }
-
+        
+        /// <summary>
+        /// Main periodic loop to run at the max rate. Flushes all queued updates immediately for maximum performance.
+        /// </summary>
+        void MainPeriodic();
+        
         /// <summary>
         /// Publishes frame data to NetworkTables.
         /// </summary>
@@ -103,7 +108,7 @@ namespace QuestNav.Network
         /// <summary>
         /// Performs periodic updates including connection polling and logging.
         /// </summary>
-        void Periodic();
+        void SlowPeriodic();
 
         /// <summary>
         /// Populates subscribed events with initial values
@@ -308,6 +313,7 @@ namespace QuestNav.Network
 
             // Standard mode: Use team number to resolve robot address
             QueuedLogger.Log($"Setting Team number to {teamNumber}");
+            ntInstance.SetAddresses(new (string addr, int port)[]{});
             ntInstance.SetTeamNumber(teamNumber, QuestNavConstants.Network.NT_SERVER_PORT);
             teamNumberSet = true;
             ipAddressSet = false;
@@ -492,9 +498,16 @@ namespace QuestNav.Network
         }
 
         /// <summary>
+        /// Main periodic loop to run at the max rate. Flushes all queued updates immediately for maximum performance.
+        /// </summary>
+        public void MainPeriodic()
+        {
+            ntInstance.Flush();
+        }
+        /// <summary>
         /// Performs periodic updates including connection polling and logging.
         /// </summary>
-        public void Periodic()
+        public void SlowPeriodic()
         {
             PollForNewIpAddress();
             PollForConnectionStatus();


### PR DESCRIPTION
Closes #143 

We can easily implement latency-compensated position resets by maintaining a CircularBuffer/FIFO Queue on the Quest of the positions for the last 1/2 second. Then once we receive a reset request, get what the quest's position was at that time and calculate the offset based on that. Apply the new position.