### PR TITLE
Docs - Fix questPose3d method name

### DIFF
--- a/docs/docs/1-getting-started/7-robot-code.mdx
+++ b/docs/docs/1-getting-started/7-robot-code.mdx
@@ -75,7 +75,7 @@ PoseFrame[] poseFrames = questNav.getAllUnreadPoseFrames();
 
 if (poseFrames.length > 0) {
     // Get the most recent Quest pose
-    Pose3d questPose = poseFrames[poseFrames.length - 1].questPose();
+    Pose3d questPose = poseFrames[poseFrames.length - 1].questPose3d();
 
     // Transform by the mount pose to get your robot pose
     Pose3d robotPose = questPose.transformBy(ROBOT_TO_QUEST.inverse());

--- a/docs/versioned_docs/version-2026-1.0.0/1-getting-started/7-robot-code.mdx
+++ b/docs/versioned_docs/version-2026-1.0.0/1-getting-started/7-robot-code.mdx
@@ -75,7 +75,7 @@ PoseFrame[] poseFrames = questNav.getAllUnreadPoseFrames();
 
 if (poseFrames.length > 0) {
     // Get the most recent Quest pose
-    Pose3d questPose = poseFrames[poseFrames.length - 1].questPose();
+    Pose3d questPose = poseFrames[poseFrames.length - 1].questPose3d();
 
     // Transform by the mount pose to get your robot pose
     Pose3d robotPose = questPose.transformBy(ROBOT_TO_QUEST.inverse());

--- a/docs/versioned_docs/version-2026-1.1.0-beta/1-getting-started/7-robot-code.mdx
+++ b/docs/versioned_docs/version-2026-1.1.0-beta/1-getting-started/7-robot-code.mdx
@@ -75,7 +75,7 @@ PoseFrame[] poseFrames = questNav.getAllUnreadPoseFrames();
 
 if (poseFrames.length > 0) {
     // Get the most recent Quest pose
-    Pose3d questPose = poseFrames[poseFrames.length - 1].questPose();
+    Pose3d questPose = poseFrames[poseFrames.length - 1].questPose3d();
 
     // Transform by the mount pose to get your robot pose
     Pose3d robotPose = questPose.transformBy(ROBOT_TO_QUEST.inverse());


### PR DESCRIPTION
I missed a spot where `questPose` needed to be renamed `questPose3d`. This applied all the way back to the beta, so all three versions are updated.