### PR TITLE
Generate BuildConfig class with version info

### DIFF
--- a/questnav-lib/build.gradle
+++ b/questnav-lib/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'maven-publish'
     id 'edu.wpi.first.GradleRIO' version '2025.3.2'
     id 'com.diffplug.spotless' version '6.20.0'
+    id 'com.github.gmazzo.buildconfig' version '6.0.7'
 }
 
 // Version and build configuration
@@ -244,6 +245,17 @@ clean {
     delete "$buildDir/outputs"
 }
 
+// Generates build config class for version info on robot.
+// WPILib uses a shadow JAR, so it doesn't include library manifests on the robot.
+buildConfig {
+    packageName("gg.questnav.questnav")
+
+    buildConfigField(String, 'APP_NAME', project.name)
+    buildConfigField(String, "APP_VERSION", provider { version })
+    buildConfigField(String, "BUILD_TIMESTAMP", provider { new Date().format("yyyy-MM-dd HH:mm:ss") })
+}
+
+// Add manifest to JAR (does not get deployed to the robot.)
 jar {
     manifest {
         attributes(

--- a/questnav-lib/src/main/java/gg/questnav/questnav/QuestNav.java
+++ b/questnav-lib/src/main/java/gg/questnav/questnav/QuestNav.java
@@ -597,14 +597,10 @@ public class QuestNav {
   /**
    * Retrieves the QuestNav-lib version number.
    *
-   * @return The version number as a String, or "0-0.0.0" if unable to retrieve.
+   * @return The version number as a String.
    */
   public String getLibVersion() {
-    var version = QuestNav.class.getPackage().getImplementationVersion();
-    if (version == null) {
-      return "0-0.0.0";
-    }
-    return version;
+    return BuildConfig.APP_VERSION;
   }
 
   /**


### PR DESCRIPTION
Generates a class with questnavlib version information so it won't get stripped out when deployed to the robot.
I have only tested this in the sim.

Resolves #163 