### PR TITLE
Convert from CV>FRC space, swap corner order passed to solver

### DIFF
--- a/unity/Assets/QuestNav/Camera/PassthroughFrameSource.cs
+++ b/unity/Assets/QuestNav/Camera/PassthroughFrameSource.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using LibJpegTurboUnity;
 using Meta.XR;
 using QuestNav.Config;
-using QuestNav.Core;
 using QuestNav.Native.AprilTag;
 using QuestNav.Native.PoseLib;
 using QuestNav.Network;
@@ -315,7 +314,12 @@ namespace QuestNav.Camera
 
                     if (poseResult != null)
                     {
-                        Debug.Log(poseResult.CameraPose);
+                        Debug.Log($"Camera Pose: {poseResult.CameraPose}");
+
+                        var (frcPos, frcRot) = Conversions.CvToFrc(poseResult.CameraPose);
+                        Debug.Log(
+                            $"FRC Pose: Pos({frcPos.x:F3}, {frcPos.y:F3}, {frcPos.z:F3}) Rot({frcRot.eulerAngles.x:F3}, {frcRot.eulerAngles.y:F3}, {frcRot.eulerAngles.z})"
+                        );
                     }
                     else
                     {

--- a/unity/Assets/QuestNav/Native/PoseLib/PoseLibSolver.cs
+++ b/unity/Assets/QuestNav/Native/PoseLib/PoseLibSolver.cs
@@ -24,17 +24,17 @@ namespace QuestNav.Native.PoseLib
 
             foreach (var detection in detections)
             {
-                corners2d.Add(detection.CornerBottomLeft0.x);
-                corners2d.Add(detection.CornerBottomLeft0.y);
-
                 corners2d.Add(detection.CornerBottomRight1.x);
                 corners2d.Add(detection.CornerBottomRight1.y);
 
-                corners2d.Add(detection.CornerUpperRight2.x);
-                corners2d.Add(detection.CornerUpperRight2.y);
+                corners2d.Add(detection.CornerBottomLeft0.x);
+                corners2d.Add(detection.CornerBottomLeft0.y);
 
                 corners2d.Add(detection.CornerUpperLeft3.x);
                 corners2d.Add(detection.CornerUpperLeft3.y);
+
+                corners2d.Add(detection.CornerUpperRight2.x);
+                corners2d.Add(detection.CornerUpperRight2.y);
 
                 var corner3dTranslations = fieldLayout.GetTagCorners(detection.Id);
                 foreach (var corner3d in corner3dTranslations)


### PR DESCRIPTION
This worked at my house (not on a field) with tags 31 and 32 taped to the wall. With the Quest pointed toward the tags, I got:
```
2026/01/18 19:16:35.202 6724 6758 Info Unity FRC Pose: Pos(1.939, 3.917, 0.858) Rot(0.361, 347.858, 180.9147)
```