### PR TITLE
Pause passthrough frame capture when there are no cliente

### DIFF
--- a/questnav-web-ui/src/components/CameraView.vue
+++ b/questnav-web-ui/src/components/CameraView.vue
@@ -204,6 +204,7 @@ function handleFullscreenChange() {
 watch(streamEnabled, (newValue, oldValue) => {
   if (newValue && !oldValue) {
     loadVideoModes()
+    cacheBuster.value = Date.now()
   }
 })
 

--- a/unity/Assets/QuestNav/WebServer/Server/ConfigServer.cs
+++ b/unity/Assets/QuestNav/WebServer/Server/ConfigServer.cs
@@ -136,6 +136,7 @@ namespace QuestNav.WebServer.Server
                 .WithModule(new ActionModule("/api", HttpVerbs.Any, HandleApiRequest))
                 .WithModule(new ActionModule("/video", HttpVerbs.Get, HandleVideoStream))
                 .WithStaticFolder("/", staticPath, true);
+            server.Listener.IgnoreWriteExceptions = false;
 
             server.StateChanged += (s, e) =>
             {


### PR DESCRIPTION
This pauses video capture and compression when there are no open stream connections.

In order to be thread safe, the implementation uses a supplier that is called from the coroutine. Using a simple method to pause and resume from the VideoStreamProvider could cause a race condition, since the actual pause/resume happens in the coroutine. Although we won't likely have a lot of clients coming and going, I can envision a scenario with poor network conditions causing a dashboard to drop and reconnect repeatedly, which could trigger a race condition.