### PR TITLE
AprilTag configuration

### DIFF
--- a/docs/docs/1-getting-started/4-app-setup.md
+++ b/docs/docs/1-getting-started/4-app-setup.md
@@ -62,7 +62,7 @@ After installation, you can launch QuestNav in several ways:
 
 2. **Using ADB**:
    ```
-   adb shell am start -n gg.questnav.questnav/.MainActivity
+   adb shell am start -n gg.QuestNav.QuestNav/com.unity3d.player.UnityPlayerGameActivity
    ```
 
 :::note

--- a/questnav-web-ui/package-lock.json
+++ b/questnav-web-ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "pinia": "^2.3.1",
-        "vue": "^3.5.26"
+        "vue": "^3.5.28"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.4",
@@ -37,12 +37,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -772,39 +772,39 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.26.tgz",
-      "integrity": "sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==",
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.28.tgz",
+      "integrity": "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@vue/shared": "3.5.26",
-        "entities": "^7.0.0",
+        "@babel/parser": "^7.29.0",
+        "@vue/shared": "3.5.28",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.26.tgz",
-      "integrity": "sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==",
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.28.tgz",
+      "integrity": "sha512-/1ZepxAb159jKR1btkefDP+J2xuWL5V3WtleRmxaT+K2Aqiek/Ab/+Ebrw2pPj0sdHO8ViAyyJWfhXXOP/+LQA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.26",
-        "@vue/shared": "3.5.26"
+        "@vue/compiler-core": "3.5.28",
+        "@vue/shared": "3.5.28"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.26.tgz",
-      "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.28.tgz",
+      "integrity": "sha512-6TnKMiNkd6u6VeVDhZn/07KhEZuBSn43Wd2No5zaP5s3xm8IqFTHBj84HJah4UepSUJTro5SoqqlOY22FKY96g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@vue/compiler-core": "3.5.26",
-        "@vue/compiler-dom": "3.5.26",
-        "@vue/compiler-ssr": "3.5.26",
-        "@vue/shared": "3.5.26",
+        "@babel/parser": "^7.29.0",
+        "@vue/compiler-core": "3.5.28",
+        "@vue/compiler-dom": "3.5.28",
+        "@vue/compiler-ssr": "3.5.28",
+        "@vue/shared": "3.5.28",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
         "postcss": "^8.5.6",
@@ -812,13 +812,13 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.26.tgz",
-      "integrity": "sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==",
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.28.tgz",
+      "integrity": "sha512-JCq//9w1qmC6UGLWJX7RXzrGpKkroubey/ZFqTpvEIDJEKGgntuDMqkuWiZvzTzTA5h2qZvFBFHY7fAAa9475g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.26",
-        "@vue/shared": "3.5.26"
+        "@vue/compiler-dom": "3.5.28",
+        "@vue/shared": "3.5.28"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -852,53 +852,53 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.26.tgz",
-      "integrity": "sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==",
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.28.tgz",
+      "integrity": "sha512-gr5hEsxvn+RNyu9/9o1WtdYdwDjg5FgjUSBEkZWqgTKlo/fvwZ2+8W6AfKsc9YN2k/+iHYdS9vZYAhpi10kNaw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.26"
+        "@vue/shared": "3.5.28"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.26.tgz",
-      "integrity": "sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==",
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.28.tgz",
+      "integrity": "sha512-POVHTdbgnrBBIpnbYU4y7pOMNlPn2QVxVzkvEA2pEgvzbelQq4ZOUxbp2oiyo+BOtiYlm8Q44wShHJoBvDPAjQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.26",
-        "@vue/shared": "3.5.26"
+        "@vue/reactivity": "3.5.28",
+        "@vue/shared": "3.5.28"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.26.tgz",
-      "integrity": "sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==",
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.28.tgz",
+      "integrity": "sha512-4SXxSF8SXYMuhAIkT+eBRqOkWEfPu6nhccrzrkioA6l0boiq7sp18HCOov9qWJA5HML61kW8p/cB4MmBiG9dSA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.26",
-        "@vue/runtime-core": "3.5.26",
-        "@vue/shared": "3.5.26",
+        "@vue/reactivity": "3.5.28",
+        "@vue/runtime-core": "3.5.28",
+        "@vue/shared": "3.5.28",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.26.tgz",
-      "integrity": "sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==",
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.28.tgz",
+      "integrity": "sha512-pf+5ECKGj8fX95bNincbzJ6yp6nyzuLDhYZCeFxUNp8EBrQpPpQaLX3nNCp49+UbgbPun3CeVE+5CXVV1Xydfg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.26",
-        "@vue/shared": "3.5.26"
+        "@vue/compiler-ssr": "3.5.28",
+        "@vue/shared": "3.5.28"
       },
       "peerDependencies": {
-        "vue": "3.5.26"
+        "vue": "3.5.28"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.26.tgz",
-      "integrity": "sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==",
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.28.tgz",
+      "integrity": "sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==",
       "license": "MIT"
     },
     "node_modules/balanced-match": {
@@ -935,9 +935,9 @@
       "dev": true
     },
     "node_modules/entities": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.0.tgz",
-      "integrity": "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -1253,16 +1253,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
-      "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
+      "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.26",
-        "@vue/compiler-sfc": "3.5.26",
-        "@vue/runtime-dom": "3.5.26",
-        "@vue/server-renderer": "3.5.26",
-        "@vue/shared": "3.5.26"
+        "@vue/compiler-dom": "3.5.28",
+        "@vue/compiler-sfc": "3.5.28",
+        "@vue/runtime-dom": "3.5.28",
+        "@vue/server-renderer": "3.5.28",
+        "@vue/shared": "3.5.28"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/questnav-web-ui/package.json
+++ b/questnav-web-ui/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "pinia": "^2.3.1",
-    "vue": "^3.5.26"
+    "vue": "^3.5.28"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.4",

--- a/questnav-web-ui/src/components/AprilTagView.vue
+++ b/questnav-web-ui/src/components/AprilTagView.vue
@@ -1,0 +1,335 @@
+<template>
+  <div class="settings-grid">
+    <!-- AprilTag Detector Enable/Disable -->
+    <ConfigField title="AprilTag Detector" description="Enable AprilTag detection for pose estimation"
+      control-class="checkbox-control">
+      <label class="checkbox-label">
+        <input type="checkbox" :checked="configStore.config?.enableAprilTagDetector ?? false"
+          @change="handleDetectorEnabledChange" />
+        {{ configStore.config?.enableAprilTagDetector ? 'Enabled' : 'Disabled' }}
+      </label>
+    </ConfigField>
+
+    <!-- Detection Mode -->
+    <ConfigField v-if="configStore.config?.enableAprilTagDetector" title="Detection Mode" control-class="input-control">
+      <template #description>
+        <div><strong>Traditional</strong> - PnP solving</div>
+        <div><strong>Anchor Enhanced</strong> - PnP solving + spatial anchors for enhanced performance</div>
+      </template>
+      <template #badge>
+        <span v-if="isModeFieldDirty" class="dirty-badge">●</span>
+      </template>
+      <select :value="pendingMode.mode" @change="handleModeChange">
+        <option value="0">Traditional</option>
+        <option value="1">Anchor Enhanced</option>
+      </select>
+    </ConfigField>
+
+    <!-- Detection Resolution -->
+    <ConfigField v-if="configStore.config?.enableAprilTagDetector" title="Detection Resolution"
+      description="Camera resolution for AprilTag detection (Width x Height @ Framerate)" control-class="input-control">
+      <template #badge>
+        <span v-if="isResolutionFieldDirty" class="dirty-badge">●</span>
+      </template>
+      <div style="display: flex; gap: 0.5rem; align-items: center;">
+        <input type="text" :value="pendingMode.width" @input="handleWidthChange" style="width: 75px;"
+          placeholder="Width" />
+        <span>×</span>
+        <input type="text" :value="pendingMode.height" @input="handleHeightChange" style="width: 75px;"
+          placeholder="Height" />
+        <span>@</span>
+        <input type="text" :value="pendingMode.framerate" @input="handleFramerateChange" style="width: 75px;"
+          placeholder="FPS" />
+        <span>fps</span>
+      </div>
+    </ConfigField>
+
+    <!-- Detection Range -->
+    <ConfigField v-if="configStore.config?.enableAprilTagDetector" title="Detection Range"
+      description="Maximum distance for tag detection" control-class="input-control">
+      <template #badge>
+        <span v-if="isMaxDistanceFieldDirty" class="dirty-badge">●</span>
+      </template>
+      <input type="range" :value="pendingMode.maxDistance" @input="handleMaxDistanceChange" min="0.5" max="10"
+        step="0.1" style="flex: 2;" />
+      <span class="range-value">{{ pendingMode.maxDistance }}m</span>
+    </ConfigField>
+
+    <!-- Minimum Tags -->
+    <ConfigField v-if="configStore.config?.enableAprilTagDetector" title="Minimum Tags Required"
+      description="Minimum number of tags needed for pose estimation" control-class="input-control">
+      <template #badge>
+        <span v-if="isMinTagsFieldDirty" class="dirty-badge">●</span>
+      </template>
+      <input type="text" :value="pendingMode.minimumNumberOfTags" @input="handleMinimumTagsChange" />
+    </ConfigField>
+
+    <!-- Allowed Tag IDs -->
+    <ConfigField v-if="configStore.config?.enableAprilTagDetector" title="Allowed Tag IDs"
+      description="Comma-separated list of allowed AprilTag IDs (leave empty for all)" control-class="input-control">
+      <template #badge>
+        <span v-if="isAllowedIdsFieldDirty" class="dirty-badge">●</span>
+      </template>
+      <input type="text" :value="allowedIdsText" @input="handleAllowedIdsChange" placeholder="e.g., 1,2,3,4" />
+    </ConfigField>
+  </div>
+
+  <!-- Apply Button Section -->
+  <div v-if="configStore.config?.enableAprilTagDetector">
+    <div class="apply-buttons">
+      <button @click="submitModeSettings" :disabled="!hasModeChanged" class="submit-button primary">
+        Apply
+      </button>
+      <button @click="cancelChanges" :disabled="!hasModeChanged" class="cancel-button">
+        Cancel
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, inject } from 'vue'
+import { useConfigStore } from '../stores/config'
+import type { AprilTagDetectorMode } from '../types'
+import ConfigField from './ConfigField.vue'
+
+// Use mock store if available (for testing), otherwise use real store
+const injectedStore = inject('configStore', null)
+const configStore = injectedStore || (window as any).__MOCK_CONFIG_STORE__ || useConfigStore()
+
+// Pending changes for batch updates
+const pendingMode = ref<AprilTagDetectorMode>({
+  mode: 0,
+  width: 640,
+  height: 480,
+  framerate: 30,
+  allowedIds: [],
+  maxDistance: 4.0,
+  minimumNumberOfTags: 2
+})
+
+// Track which specific fields the user has actually modified
+const userModifiedFields = ref<Set<string>>(new Set())
+
+// Initialize pending mode when config loads
+watch(() => configStore.config?.aprilTagDetectorMode, (newMode) => {
+  if (newMode) {
+    // On background refresh, only update fields that user hasn't modified
+    if (userModifiedFields.value.size === 0) {
+      // No user modifications, safe to update everything
+      pendingMode.value = { ...newMode }
+    } else {
+      // Selectively update only non-user-modified fields
+      const updated = { ...pendingMode.value }
+
+      if (!userModifiedFields.value.has('mode')) updated.mode = newMode.mode
+      if (!userModifiedFields.value.has('width')) updated.width = newMode.width
+      if (!userModifiedFields.value.has('height')) updated.height = newMode.height
+      if (!userModifiedFields.value.has('framerate')) updated.framerate = newMode.framerate
+      if (!userModifiedFields.value.has('maxDistance')) updated.maxDistance = newMode.maxDistance
+      if (!userModifiedFields.value.has('minimumNumberOfTags')) updated.minimumNumberOfTags = newMode.minimumNumberOfTags
+      if (!userModifiedFields.value.has('allowedIds')) updated.allowedIds = [...newMode.allowedIds]
+
+      pendingMode.value = updated
+    }
+  }
+}, { immediate: true })
+
+// Computed for allowed IDs text representation
+const allowedIdsText = computed({
+  get: () => pendingMode.value.allowedIds.join(','),
+  set: (value: string) => {
+    const ids = value.split(',')
+      .map(id => parseInt(id.trim()))
+      .filter(id => !isNaN(id) && id >= 0)
+    pendingMode.value.allowedIds = ids
+    // Don't auto-mark as modified here - let the change handler do it
+  }
+})
+
+// Check if mode settings have changed
+const hasModeChanged = computed(() => {
+  return userModifiedFields.value.size > 0
+})
+
+// Individual field dirty state indicators (only show dirty if user actually modified them)
+const isModeFieldDirty = computed(() => {
+  return userModifiedFields.value.has('mode')
+})
+
+const isResolutionFieldDirty = computed(() => {
+  return userModifiedFields.value.has('width') ||
+    userModifiedFields.value.has('height') ||
+    userModifiedFields.value.has('framerate')
+})
+
+const isMaxDistanceFieldDirty = computed(() => {
+  return userModifiedFields.value.has('maxDistance')
+})
+
+const isMinTagsFieldDirty = computed(() => {
+  return userModifiedFields.value.has('minimumNumberOfTags')
+})
+
+const isAllowedIdsFieldDirty = computed(() => {
+  return userModifiedFields.value.has('allowedIds')
+})
+
+// Event handlers
+async function handleDetectorEnabledChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  await configStore.updateEnableAprilTagDetector(target.checked)
+}
+
+function handleModeChange(event: Event) {
+  const target = event.target as HTMLSelectElement
+  pendingMode.value.mode = parseInt(target.value)
+  userModifiedFields.value.add('mode')
+}
+
+function handleWidthChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  const value = parseInt(target.value)
+  if (!isNaN(value) && value >= 160 && value <= 1920) {
+    pendingMode.value.width = value
+    userModifiedFields.value.add('width')
+  }
+}
+
+function handleHeightChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  const value = parseInt(target.value)
+  if (!isNaN(value) && value >= 120 && value <= 1080) {
+    pendingMode.value.height = value
+    userModifiedFields.value.add('height')
+  }
+}
+
+function handleFramerateChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  const value = parseInt(target.value)
+  if (!isNaN(value) && value >= 5 && value <= 60) {
+    pendingMode.value.framerate = value
+    userModifiedFields.value.add('framerate')
+  }
+}
+
+function handleMaxDistanceChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  const value = parseFloat(target.value)
+  if (!isNaN(value)) {
+    pendingMode.value.maxDistance = value
+    userModifiedFields.value.add('maxDistance')
+  }
+}
+
+function handleMinimumTagsChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  const value = parseInt(target.value)
+  if (!isNaN(value) && value >= 1 && value <= 8) {
+    pendingMode.value.minimumNumberOfTags = value
+    userModifiedFields.value.add('minimumNumberOfTags')
+  }
+}
+
+function handleAllowedIdsChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  allowedIdsText.value = target.value
+  userModifiedFields.value.add('allowedIds')
+}
+
+async function submitModeSettings() {
+  await configStore.updateAprilTagDetectorMode(pendingMode.value)
+  userModifiedFields.value.clear()
+}
+
+function cancelChanges() {
+  const current = configStore.config?.aprilTagDetectorMode
+  if (current) {
+    pendingMode.value = { ...current }
+    userModifiedFields.value.clear()
+  }
+}
+</script>
+
+<style scoped>
+.dirty-badge {
+  color: #ff9500;
+  font-size: 14px;
+  margin-left: 6px;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.6;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.apply-buttons {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  padding-top: 1.5rem;
+  padding-right: 0.5rem;
+}
+
+.submit-button,
+.cancel-button {
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.submit-button:disabled,
+.cancel-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.submit-button.primary {
+  background: var(--primary-color);
+  color: white;
+  border-color: var(--primary-color);
+}
+
+.submit-button.primary:hover:not(:disabled) {
+  background: var(--primary-dark);
+  border-color: var(--primary-dark);
+}
+
+.cancel-button {
+  background: var(--secondary-color);
+  color: white;
+  border-color: var(--secondary-color);
+}
+
+.cancel-button:hover:not(:disabled) {
+  background: var(--text-secondary);
+  border-color: var(--text-secondary);
+}
+
+.changes-summary {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.range-value {
+  min-width: 40px;
+  text-align: center;
+  font-weight: 500;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+</style>

--- a/questnav-web-ui/src/components/ConfigField.vue
+++ b/questnav-web-ui/src/components/ConfigField.vue
@@ -68,12 +68,23 @@ defineProps<{
   gap: 0.5rem;
 }
 
-.input-control :deep(input) {
+.input-control :deep(input:not([type="range"])) {
   flex: 1;
-  padding: 0.75rem;
-  border: 1px solid var(--border-color);
+  padding: 0.5rem 0.75rem;
+  border: 2px solid var(--border-color);
   border-radius: 6px;
   font-size: 1rem;
+}
+
+[data-theme="dark"] .input-control :deep(input:not([type="range"])) {
+  border-color: #4a5568;
+  background: #2d3748;
+  color: #e2e8f0;
+}
+
+[data-theme="dark"] .input-control :deep(input:not([type="range"])):focus {
+  border-color: var(--primary-color);
+  background: #374151;
 }
 
 .checkbox-control {

--- a/questnav-web-ui/src/components/ConfigForm.vue
+++ b/questnav-web-ui/src/components/ConfigForm.vue
@@ -45,6 +45,11 @@
             <CameraView />
           </div>
           
+          <!-- AprilTag Tab -->
+          <div v-show="activeTab === 'AprilTag'" class="tab-panel">
+            <AprilTagView />
+          </div>
+          
           <!-- Settings Tab -->
           <div v-show="activeTab === 'Settings'" class="tab-panel">
             <div class="settings-grid">
@@ -184,7 +189,7 @@
                 description="Reset all settings to defaults"
                 field-class="reset-field"
               >
-                <button @click="handleReset" class="reset-button">Reset to Defaults</button>
+                <button @click="handleReset" class="danger">Reset to Defaults</button>
               </ConfigField>
 
               <!-- Database Management -->
@@ -194,8 +199,8 @@
                 field-class="database-field"
                 control-class="database-buttons"
               >
-                <button @click="handleDownloadDatabase" class="database-button">Download Database</button>
-                <label class="database-button upload-label">
+                <button @click="handleDownloadDatabase" class="secondary">Download Database</button>
+                <label class="secondary upload-label">
                   Upload Database
                   <input type="file" accept=".db" @change="handleUploadDatabase" hidden />
                 </label>
@@ -224,10 +229,11 @@ import StatusView from './StatusView.vue'
 import LogsView from './LogsView.vue'
 import CameraView from './CameraView.vue'
 import ConfigField from './ConfigField.vue'
+import AprilTagView from './AprilTagView.vue'
 
 const configStore = useConfigStore()
 const activeTab = ref<string>('Status')
-const tabs = ['Status', 'Logs', 'Camera', 'Settings']
+const tabs = ['Status', 'Logs', 'Camera', 'AprilTag', 'Settings']
 let pollInterval: number | null = null
 
 const pendingTeamNumber = ref<number | null>(null)
@@ -408,12 +414,6 @@ async function handleUploadDatabase(event: Event) {
   min-height: 400px;
 }
 
-.settings-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 1.5rem;
-}
-
 .debug-badge, .override-badge {
   font-size: 0.7rem;
   padding: 0.2rem 0.5rem;
@@ -436,56 +436,8 @@ async function handleUploadDatabase(event: Event) {
   margin-top: 0.5rem;
 }
 
-.submit-button {
-  padding: 0.75rem 1.25rem;
-  background: var(--primary-color);
-  color: white;
-  border: none;
-  border-radius: 6px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.checkbox-label {
-  font-weight: 500;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  cursor: pointer;
-}
-
-.reset-button {
-  padding: 0.75rem 1.5rem;
-  background: var(--danger-color);
-  color: white;
-  border: none;
-  border-radius: 6px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.database-button {
-  padding: 0.75rem 1.5rem;
-  background: var(--card-bg);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.database-button:hover {
-  background: var(--border-color);
-}
-
 .upload-label {
   display: inline-block;
-}
-
-@media (max-width: 768px) {
-  .settings-grid {
-    grid-template-columns: 1fr;
-  }
 }
 </style>
 

--- a/questnav-web-ui/src/stores/config.ts
+++ b/questnav-web-ui/src/stores/config.ts
@@ -2,7 +2,7 @@
 
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import type { ConfigResponse, StreamModeModel } from '../types'
+import type { ConfigResponse, StreamModeModel, AprilTagDetectorMode } from '../types'
 import { configApi } from '../api/config'
 
 export const useConfigStore = defineStore('config', () => {
@@ -128,6 +128,32 @@ export const useConfigStore = defineStore('config', () => {
     }
   }
 
+  async function updateEnableAprilTagDetector(value: boolean) {
+    try {
+      const response = await configApi.updateConfig({ enableAprilTagDetector: value })
+      if (response.success) {
+        await loadConfig(false)
+      }
+      return response.success
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to update'
+      return false
+    }
+  }
+
+  async function updateAprilTagDetectorMode(value: AprilTagDetectorMode) {
+    try {
+      const response = await configApi.updateConfig({ aprilTagDetectorMode: value })
+      if (response.success && config.value) {
+        config.value.aprilTagDetectorMode = value
+      }
+      return response.success
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to update'
+      return false
+    }
+  }
+
   async function resetToDefaults() {
     try {
       const response = await configApi.resetConfig()
@@ -157,6 +183,8 @@ export const useConfigStore = defineStore('config', () => {
     updateEnableHighQualityStream,
     updateEnableDebugLogging,
     updateStreamMode,
+    updateEnableAprilTagDetector,
+    updateAprilTagDetectorMode,
     resetToDefaults
   }
 })

--- a/questnav-web-ui/src/style.css
+++ b/questnav-web-ui/src/style.css
@@ -174,10 +174,10 @@ textarea {
   width: 100%;
   padding: 0.5rem 0.75rem;
   background-color: var(--input-bg);
-  border: 1px solid var(--border-color);
+  border: 2px solid var(--border-color);
   border-radius: 6px;
   color: var(--text-primary);
-  transition: border-color 0.2s;
+  transition: all 0.2s ease;
 }
 
 input[type="text"]:focus,
@@ -186,6 +186,33 @@ select:focus,
 textarea:focus {
   outline: none;
   border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(51, 161, 253, 0.1);
+}
+
+/* Dark mode form control improvements */
+[data-theme="dark"] input[type="text"],
+[data-theme="dark"] input[type="number"],
+[data-theme="dark"] select,
+[data-theme="dark"] textarea {
+  border-color: #4a5568;
+  background: #2d3748;
+  color: #e2e8f0;
+}
+
+[data-theme="dark"] input[type="text"]:focus,
+[data-theme="dark"] input[type="number"]:focus,
+[data-theme="dark"] select:focus,
+[data-theme="dark"] textarea:focus {
+  border-color: var(--primary-color);
+  background: #374151;
+}
+
+.checkbox-label {
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
 }
 
 input[type="checkbox"] {
@@ -200,7 +227,7 @@ input[type="checkbox"] {
   appearance: none;
   border: 2px solid var(--border-color);
   border-radius: 4px;
-  background-color: var(--primary-color);
+  background-color: var(--bg-color);
   transition: all 0.2s ease;
   position: relative;
   flex-shrink: 0;
@@ -208,11 +235,16 @@ input[type="checkbox"] {
 
 input[type="checkbox"]:checked {
   background-color: var(--primary-color);
-  border-color: var(--border-color);
+  border-color: var(--primary-color);
 }
 
 input[type="checkbox"]:hover {
   border-color: var(--primary-color);
+}
+
+input[type="checkbox"]:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(51, 161, 253, 0.1);
 }
 
 input[type="checkbox"]:checked::after {
@@ -227,33 +259,72 @@ input[type="checkbox"]:checked::after {
   transform: translate(-50%, -60%) rotate(45deg);
 }
 
+[data-theme="dark"] input[type="checkbox"] {
+  border-color: #4a5568;
+  background-color: #2d3748;
+}
+
+[data-theme="dark"] input[type="checkbox"]:checked {
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+}
+
 input[type="range"] {
   width: 100%;
-  height: 6px;
-  background: var(--bg-tertiary);
-  border-radius: 3px;
+  height: 8px;
+  background: var(--input-bg);
+  border: 2px solid var(--border-color);
+  border-radius: 6px;
   outline: none;
   -webkit-appearance: none;
+  transition: all 0.2s ease;
+}
+
+input[type="range"]:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(51, 161, 253, 0.1);
+}
+
+/* Dark mode range improvements */
+[data-theme="dark"] input[type="range"] {
+  border-color: #4a5568;
+  background: #2d3748;
+}
+
+[data-theme="dark"] input[type="range"]:focus {
+  border-color: var(--primary-color);
 }
 
 input[type="range"]::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
   background: var(--primary-color);
   border-radius: 50%;
   cursor: pointer;
+  border: 2px solid var(--bg-color);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 }
 
 input[type="range"]::-moz-range-thumb {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
   background: var(--primary-color);
   border-radius: 50%;
   cursor: pointer;
-  border: none;
+  border: 2px solid var(--bg-color);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   appearance: none;
+}
+
+/* Dark mode slider thumb improvements */
+[data-theme="dark"] input[type="range"]::-webkit-slider-thumb {
+  border-color: #2d3748;
+}
+
+[data-theme="dark"] input[type="range"]::-moz-range-thumb {
+  border-color: #2d3748;
 }
 
 input[type="color"] {
@@ -379,4 +450,17 @@ button.danger:hover {
 .justify-between { justify-content: space-between; }
 .gap-1 { gap: 0.5rem; }
 .gap-2 { gap: 1rem; }
+
+/* Layout Components */
+.settings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .settings-grid {
+    grid-template-columns: 1fr;
+  }
+}
 

--- a/questnav-web-ui/src/types.ts
+++ b/questnav-web-ui/src/types.ts
@@ -13,6 +13,16 @@ export interface VideoModeModel {
   framerate: number
 }
 
+export interface AprilTagDetectorMode {
+  mode: number
+  width: number
+  height: number
+  framerate: number
+  allowedIds: number[]
+  maxDistance: number
+  minimumNumberOfTags: number
+}
+
 export interface ConfigResponse {
   success: boolean
   teamNumber: number
@@ -22,6 +32,8 @@ export interface ConfigResponse {
   enableHighQualityStream: boolean
   enableDebugLogging: boolean
   streamMode: StreamModeModel
+  enableAprilTagDetector: boolean
+  aprilTagDetectorMode: AprilTagDetectorMode
   timestamp: number
 }
 
@@ -33,6 +45,8 @@ export interface ConfigUpdateRequest {
   enableHighQualityStream?: boolean
   enableDebugLogging?: boolean
   streamMode?: StreamModeModel
+  enableAprilTagDetector?: boolean
+  aprilTagDetectorMode?: AprilTagDetectorMode
 }
 
 export interface SimpleResponse {

--- a/unity/Assets/QuestNav/Config/Config.cs
+++ b/unity/Assets/QuestNav/Config/Config.cs
@@ -28,6 +28,25 @@ namespace QuestNav.Config
             public string DebugIpOverride { get; set; } = "";
         }
 
+        /// <summary>
+        /// Join table that stores allowed AprilTag family IDs for the single AprilTag config row.
+        /// </summary>
+        public class AprilTagAllowedId
+        {
+            [PrimaryKey, AutoIncrement]
+            public int ID { get; set; }
+
+            /// <summary>
+            /// Reference to the parent AprilTag config (we use ID=1 for the single config row)
+            /// </summary>
+            public int AprilTagConfigId { get; set; }
+
+            /// <summary>
+            /// The allowed AprilTag family ID
+            /// </summary>
+            public int AllowedId { get; set; }
+        }
+
         public class System
         {
             /// <summary>
@@ -54,7 +73,7 @@ namespace QuestNav.Config
             /// Whether the passthrough camera should be streamed over NT and WebUI
             /// </summary>
             public bool EnablePassthroughStream { get; set; } = false;
-            
+
             /// <summary>
             /// The width of the stream in pixels
             /// </summary>
@@ -74,13 +93,20 @@ namespace QuestNav.Config
             /// JPEG compression quality (1-100). Higher values mean better quality and larger files.
             /// </summary>
             public int PassthroughStreamQuality { get; set; } = 75;
-            
+
             /// <summary>
             /// Whether to allow high-resolution stream modes (greater than 640x480).
             /// </summary>
             public bool EnableHighQualityStreams { get; set; } = false;
         }
 
+        /// <summary>
+        /// ApriTag detection configuration.
+        /// </summary>
+        /// <remarks>
+        /// NOTE: allowed IDs are stored in a separate table `AprilTagAllowedId`.
+        /// See ConfigManager to read/write.
+        /// </remarks>
         public class AprilTag
         {
             /// <summary>
@@ -90,44 +116,50 @@ namespace QuestNav.Config
             public int ID { get; set; }
 
             /// <summary>
-            /// Whether the AprilTag detector is enabled.
+            /// Whether the AprilTag detector is enabled. Default is true.
             /// </summary>
             public bool EnableAprilTagDetector { get; set; } = true;
 
             /// <summary>
             /// The mode to detect using.
-            /// <ul>TRADITIONAL = 0</ul>
-            /// <ul>ANCHOR_ENHANCED = 1</ul>
             /// </summary>
-            public int AprilTagDetectorMode { get; set; } = (int) Config.AprilTagDetectorMode.DetectionMode.TRADITIONAL;
+            /// <remarks>
+            /// <list type="table">
+            /// <item>
+            /// <term><c>TRADITIONAL</c></term>
+            /// <description>Uses traditional PnP solving for tag detection.</description>
+            /// </item>
+            /// <item>
+            /// <term><c>ANCHOR_ENHANCED</c></term>
+            /// <description>Uses PnP solving combined with Meta Quest spatial anchors for enhanced performance.</description>
+            /// </item>
+            /// </list>
+            /// Default is <c>TRADITIONAL</c>.
+            /// </remarks>
+            public int AprilTagDetectorMode { get; set; } = (int)Config.AprilTagDetectorMode.DetectionMode.TRADITIONAL;
 
             /// <summary>
-            /// The width of the detection region in pixels.
+            /// The width of the detection region in pixels. Default is 640.
             /// </summary>
             public int AprilTagDetectorWidth { get; set; } = 640;
 
             /// <summary>
-            /// The height of the detection region in pixels.
+            /// The height of the detection region in pixels. Default is 480.
             /// </summary>
             public int AprilTagDetectorHeight { get; set; } = 480;
 
             /// <summary>
-            /// The detection framerate in frames per second.
+            /// The detection framerate in frames per second. Default is 30.
             /// </summary>
             public int AprilTagDetectorFramerate { get; set; } = 30;
 
             /// <summary>
-            /// Array of AprilTag family IDs to detect. Empty array detects all families.
-            /// </summary>
-            public int[] AprilTagDetectorAllowedIds { get; set; } = {};
-
-            /// <summary>
-            /// Maximum detection distance in meters.
+            /// Maximum detection distance in meters. Default is 4.0 meters.
             /// </summary>
             public double AprilTagDetectorMaxDistance { get; set; } = 4.0;
 
             /// <summary>
-            /// Minimum number of tags required to report a valid pose.
+            /// Minimum number of tags required to report a valid pose. Default is 2.
             /// </summary>
             public int AprilTagDetectorMinimumNumberOfTags { get; set; } = 2;
         }
@@ -198,7 +230,7 @@ namespace QuestNav.Config
         public readonly struct AprilTagDetectorMode
         {
             public DetectionMode Mode { get; }
-            
+
             public enum DetectionMode
             {
                 /// <summary>

--- a/unity/Assets/QuestNav/Network/NetworkTableConnection.cs
+++ b/unity/Assets/QuestNav/Network/NetworkTableConnection.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Net;
-using System.Net.Sockets;
 using QuestNav.Config;
 using QuestNav.Core;
 using QuestNav.Native.NTCore;
 using QuestNav.Protos.Generated;
 using QuestNav.Utils;
+using System;
+using System.Net;
+using System.Net.Sockets;
 using UnityEngine;
 
 namespace QuestNav.Network
@@ -560,6 +560,13 @@ namespace QuestNav.Network
         /// </summary>
         private void PollInternalNtLog()
         {
+            if (ntInstanceLogger == null)
+            {
+                QueuedLogger.LogWarning(
+                        "NT Instance logger not initialized"
+                    );
+                return;
+            }
             var messages = ntInstanceLogger.PollForMessages();
             if (messages == null)
                 return;

--- a/unity/Assets/QuestNav/WebServer/Models/ConfigModel.cs
+++ b/unity/Assets/QuestNav/WebServer/Models/ConfigModel.cs
@@ -27,6 +27,21 @@ namespace QuestNav.WebServer
     }
 
     /// <summary>
+    /// AprilTag detector configuration for web API
+    /// </summary>
+    [Serializable]
+    public class AprilTagDetectorModeModel
+    {
+        public int mode;
+        public int width;
+        public int height;
+        public int framerate;
+        public int[] allowedIds;
+        public double maxDistance;
+        public int minimumNumberOfTags;
+    }
+
+    /// <summary>
     /// Current configuration values response
     /// </summary>
     [Serializable]
@@ -39,6 +54,8 @@ namespace QuestNav.WebServer
         public bool enablePassthroughStream;
         public bool enableHighQualityStream;
         public StreamModeModel streamMode;
+        public bool enableAprilTagDetector;
+        public AprilTagDetectorModeModel aprilTagDetectorMode;
         public bool enableDebugLogging;
         public long timestamp;
     }
@@ -55,6 +72,8 @@ namespace QuestNav.WebServer
         public bool? EnablePassthroughStream;
         public bool? EnableHighQualityStream;
         public StreamModeModel StreamMode;
+        public bool? EnableAprilTagDetector;
+        public AprilTagDetectorModeModel AprilTagDetectorMode;
         public bool? EnableDebugLogging;
     }
 

--- a/unity/Assets/QuestNav/WebServer/Server/ConfigServer.cs
+++ b/unity/Assets/QuestNav/WebServer/Server/ConfigServer.cs
@@ -341,6 +341,7 @@ namespace QuestNav.WebServer.Server
         private async Task HandleGetConfig(IHttpContext context)
         {
             var streamMode = await configManager.GetPassthroughStreamModeAsync();
+            var aprilTagDetectorMode = await configManager.GetAprilTagDetectorModeAsync();
             var response = new ConfigResponse
             {
                 success = true,
@@ -355,6 +356,17 @@ namespace QuestNav.WebServer.Server
                     height = streamMode.Height,
                     framerate = streamMode.Framerate,
                     quality = streamMode.Quality,
+                },
+                enableAprilTagDetector = await configManager.GetEnableAprilTagDetectorAsync(),
+                aprilTagDetectorMode = new AprilTagDetectorModeModel
+                {
+                    mode = (int)aprilTagDetectorMode.Mode,
+                    width = aprilTagDetectorMode.Width,
+                    height = aprilTagDetectorMode.Height,
+                    framerate = aprilTagDetectorMode.Framerate,
+                    allowedIds = aprilTagDetectorMode.AllowedIds,
+                    maxDistance = aprilTagDetectorMode.MaxDistance,
+                    minimumNumberOfTags = aprilTagDetectorMode.MinimumNumberOfTags,
                 },
                 enableDebugLogging = await configManager.GetEnableDebugLoggingAsync(),
                 timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
@@ -413,6 +425,26 @@ namespace QuestNav.WebServer.Server
                             request.StreamMode.height,
                             request.StreamMode.framerate,
                             request.StreamMode.quality
+                        )
+                    );
+                }
+                if (request.EnableAprilTagDetector.HasValue)
+                {
+                    await configManager.SetEnableAprilTagDetectorAsync(
+                        request.EnableAprilTagDetector.Value
+                    );
+                }
+                if (request.AprilTagDetectorMode != null)
+                {
+                    await configManager.SetAprilTagDetectorModeAsnyc(
+                        new AprilTagDetectorMode(
+                            (AprilTagDetectorMode.DetectionMode)request.AprilTagDetectorMode.mode,
+                            request.AprilTagDetectorMode.width,
+                            request.AprilTagDetectorMode.height,
+                            request.AprilTagDetectorMode.framerate,
+                            request.AprilTagDetectorMode.allowedIds,
+                            request.AprilTagDetectorMode.maxDistance,
+                            request.AprilTagDetectorMode.minimumNumberOfTags
                         )
                     );
                 }


### PR DESCRIPTION
This is a PR to the branch where @SeanErn is working on AprilTags. This adds AprilTag configuration to the web UI.

- There was a problem in the config that was preventing the app from starting, SQLLite does not support an int[] type, so I separated the tag IDs into a separate table.
- I wasn't sure if there was a fixed set of resolutions/fps like there are for streaming, so it's open text boxes right now.
- Finally, I did a styling rework for the dark mode. The checkboxes were still a little funky, and the text boxes and dropdowns had nearly invisible borders and their backgrounds were the same as the container background. I added more contrast.