### PR TITLE
Fix for UI getting lost after a pose reset

### DIFF
--- a/unity/Assets/QuestNav/UI/TagAlongUI.cs
+++ b/unity/Assets/QuestNav/UI/TagAlongUI.cs
@@ -45,10 +45,10 @@ namespace QuestNav.UI
 
             // 2. Calculate the target rotation
             Vector3 lookDirection = transform.position - head.position;
-            Quaternion idealRotation = Quaternion.LookRotation(lookDirection);
+            Quaternion idealRotation = Quaternion.LookRotation(lookDirection, transform.parent.up);
 
             // Determine if the UI needs to move based on position thresholds
-            Vector3 delta = transform.position - idealPosition;
+            Vector3 delta = head.InverseTransformDirection(transform.position - idealPosition);
             bool needsPositionUpdate =
                 Mathf.Abs(delta.x) > POSITION_THRESHOLD_X
                 || Mathf.Abs(delta.y) > POSITION_THRESHOLD_Y;

--- a/unity/Assets/Scenes/QuestNav.unity
+++ b/unity/Assets/Scenes/QuestNav.unity
@@ -2926,6 +2926,7 @@ Transform:
   m_Children:
   - {fileID: 1452768907}
   - {fileID: 650051658}
+  - {fileID: 773508528}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &325089086
@@ -7000,7 +7001,7 @@ RectTransform:
   - {fileID: 1252120776}
   - {fileID: 94458347}
   - {fileID: 2085233929}
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 324151953}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -16629,6 +16630,5 @@ SceneRoots:
   - {fileID: 423795833}
   - {fileID: 410087041}
   - {fileID: 336173539}
-  - {fileID: 773508528}
   - {fileID: 1420589305}
   - {fileID: 385846345}


### PR DESCRIPTION
This fixes the UI not properly following the user after a pose reset. The key difference is that the QuestNav UI is now a child of the OVRCameraRig, and `InverseTransformDirection` is used to track between the local and global space.

Resolves #168 